### PR TITLE
Add instructions for an authenticated SPARQL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ minikube service virtuoso
 After running the command, minikube will open a browser window to the
 local Virtuoso instance.
 
+### Protecting the Virtuoso SPARQLEndpoint
+We don't want open access to the `sparql/` endpoint that Virtuoso
+exposes. To protect the endpoint, follow
+[this](http://vos.openlinksw.com/owiki/wiki/VOS/VirtSPARQLProtectSQLDigestAuthentication)
+guide from Open Link. While performing 'Step 6', use the `Browse` button
+to locate the authentication function rather than copy+pasting
+`DB.DBA.HP_AUTH_SQL_USER;`, which is suggested by the guide.
+
 ## Testing
 
 Tests are written using [PyTest](http://pytest.org/latest/). Install [PyTest](http://pytest.org/latest/) with


### PR DESCRIPTION
Fixes #11 
### Summary
This PR is fairly lightweight: it's a small addition to the readme that outlines how to add authentication to the SPARQL endpoint.

### To Test
1. Deploy slinky
2. Create a user inn Virtuoso. See [this](http://vos.openlinksw.com/owiki/wiki/VOS/VirtTipsAndTricksGuideSPARQLAssignRoleToUser) guide
2. Follow the README
3. Attempt to login to the SPARQL endpoint
4. You should be prompted with a login field, your credentials should work