### PR TITLE
Restructure Deployment for Dev & Production Servers

### DIFF
--- a/deploy/templates/deployment/redis-deployment.yaml
+++ b/deploy/templates/deployment/redis-deployment.yaml
@@ -1,33 +1,4 @@
 ---
-kind: PersistentVolume
-apiVersion: v1
-metadata:
-  name: redis-pv
-  labels:
-    type: local
-spec:
-  storageClassName: "manual"
-  accessModes:
-    - ReadWriteOnce
-  capacity:
-    storage: 10Gi
-  hostPath:
-    path: "/data"
-
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: redis-pvc
-spec:
-  storageClassName: "manual"
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 3Gi
-
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -77,13 +48,13 @@ spec:
         - containerPort: 6379
         volumeMounts:
         - mountPath: /data
-          name: redis-pvc
+          name: redis-volume
         - mountPath: /redis-master
           name: config
       volumes:
-        - name: redis-pvc
+        - name: redis-volume
           persistentVolumeClaim:
-            claimName: redis-pvc
+            claimName: slinky-pvc
         - name: config
           configMap:
             name: redis-config

--- a/deploy/templates/deployment/scheduler-deployment.yaml
+++ b/deploy/templates/deployment/scheduler-deployment.yaml
@@ -23,9 +23,9 @@ spec:
           command: ["python3"]
           args: ["-u", "schedule.py"]
           volumeMounts:
-            - mountPath: /d1lod
-              name: d1lod-volume
+            - mountPath: /worker
+              name: worker-volume
       volumes:
-        - name: d1lod-volume
+        - name: worker-volume
           persistentVolumeClaim:
-            claimName: d1lod-pvc
+            claimName: slinky-pvc

--- a/deploy/templates/deployment/slinky-pvc.yaml
+++ b/deploy/templates/deployment/slinky-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: slinky
+  name: slinky-pvc
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 40Gi

--- a/deploy/templates/deployment/virtuoso-deployment.yaml
+++ b/deploy/templates/deployment/virtuoso-deployment.yaml
@@ -1,33 +1,4 @@
 ---
-kind: PersistentVolume
-apiVersion: v1
-metadata:
-  name: virtuoso-pv
-  labels:
-    type: local
-spec:
-  storageClassName: "manual"
-  accessModes:
-    - ReadWriteOnce
-  capacity:
-    storage: 10Gi
-  hostPath:
-    path: "/data"
-
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: virtuoso-pvc
-spec:
-  storageClassName: "manual"
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 3Gi
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,4 +33,4 @@ spec:
       volumes:
         - name: virtuoso-pvc
           persistentVolumeClaim:
-            claimName: virtuoso-pvc
+            claimName: slinky-pvc

--- a/deploy/templates/deployment/worker-deployment.yaml
+++ b/deploy/templates/deployment/worker-deployment.yaml
@@ -1,33 +1,4 @@
 ---
-kind: PersistentVolume
-apiVersion: v1
-metadata:
-  name: d1lod-pv
-  labels:
-    type: local
-spec:
-  storageClassName: manual
-  capacity:
-    storage: 5Gi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: "/d1lod"
-
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: d1lod-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: manual
-  resources:
-    requests:
-      storage: 5Gi
-
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,8 +25,8 @@ spec:
           args: ["-u", "work.py"]
           volumeMounts:
             - mountPath: /d1lod
-              name: d1lod-volume
+              name: worker-volume
       volumes:
-        - name: d1lod-volume
+        - name: worker-volume
           persistentVolumeClaim:
-            claimName: d1lod-pvc
+            claimName: slinky-pvc


### PR DESCRIPTION
This PR has a few small changes

1. Removes the VolumeClaim from the helm chart. This is now managed by the cluster administrator (over at [k8s-cluster](https://github.com/DataONEorg/k8s-cluster)).
2. Creates a single PersistentVolumeClaim and shares is across all pods

This is currently deployed on the development kubernetes server and all pods are stable.
Fixes #31 