### PR TITLE
Add support for EML 2.0.0 and up

### DIFF
--- a/d1lod/d1lod/client.py
+++ b/d1lod/d1lod/client.py
@@ -6,6 +6,9 @@ from datetime import datetime, timezone
 
 from .filtered_d1_client import FilteredCoordinatingNodeClient
 from .exceptions import UnsupportedFormatException, CursorSetFailedException
+from .processors.eml.eml_processor import EMLProcessor
+from .processors.eml.eml201_processor import EML201Processor
+from .processors.eml.eml210_processor import EML210Processor
 from .processors.eml.eml211_processor import EML211Processor
 from .processors.eml.eml220_processor import EML220Processor
 from .processors.iso.iso_processor import ISOProcessor
@@ -18,8 +21,11 @@ logger = logging.getLogger(__name__)
 
 
 FORMAT_MAP = {
+    "eml://ecoinformatics.org/eml-2.0.0": EMLProcessor,
+    "eml://ecoinformatics.org/eml-2.0.1": EML201Processor,
+    "eml://ecoinformatics.org/eml-2.1.0": EML210Processor,
     "eml://ecoinformatics.org/eml-2.1.1": EML211Processor,
-    "https://eml.ecoinformatics.org/eml-2.2.0": EML220Processor,
+    "eml://ecoinformatics.org/eml-2.2.0": EML220Processor,
     "http://www.isotc211.org/2005/gmd": ISOProcessor,
 }
 

--- a/d1lod/d1lod/client.py
+++ b/d1lod/d1lod/client.py
@@ -25,7 +25,7 @@ FORMAT_MAP = {
     "eml://ecoinformatics.org/eml-2.0.1": EML201Processor,
     "eml://ecoinformatics.org/eml-2.1.0": EML210Processor,
     "eml://ecoinformatics.org/eml-2.1.1": EML211Processor,
-    "eml://ecoinformatics.org/eml-2.2.0": EML220Processor,
+    "https://eml.ecoinformatics.org/eml-2.2.0": EML220Processor,
     "http://www.isotc211.org/2005/gmd": ISOProcessor,
 }
 

--- a/d1lod/d1lod/processors/eml/eml201_processor.py
+++ b/d1lod/d1lod/processors/eml/eml201_processor.py
@@ -4,16 +4,16 @@ from .eml_processor import EMLProcessor
 logger = logging.getLogger(__name__)
 
 
-class EML211Processor(EMLProcessor):
+class EML201Processor(EMLProcessor):
     """
-    Class for processing EML 2.1.1. For the moment, the graph pattern is agnostic of the
-    changes in 2.1.1. The 2.0.0 processor is used.
+    Class for processing EML 2.0.1. There aren't any changes between 2.0.0 and 2.0.1 that
+    effect the graph pattern, so the 2.0.0 processor is used.
     """
 
     def __init__(self, client, model, sysmeta, scimeta, parts):
         super().__init__(client, model, sysmeta, scimeta, parts)
 
     def process(self):
-        logger.debug(f"EML211Processor.process '{self.identifier}'")
-
+        logger.debug(f"EML201Processor.process '{self.identifier}'")
+        # Use the 2.0.0 processor
         return super().process()

--- a/d1lod/d1lod/processors/eml/eml210_processor.py
+++ b/d1lod/d1lod/processors/eml/eml210_processor.py
@@ -4,16 +4,17 @@ from .eml_processor import EMLProcessor
 logger = logging.getLogger(__name__)
 
 
-class EML211Processor(EMLProcessor):
+class EML210Processor(EMLProcessor):
     """
-    Class for processing EML 2.1.1. For the moment, the graph pattern is agnostic of the
-    changes in 2.1.1. The 2.0.0 processor is used.
+    Class for processing EML 2.1.0 documents. There aren't any changes
+    between 2.0.0 and 2.1.0 that effect the current graph pattern, so the base
+    processor is used.
     """
 
     def __init__(self, client, model, sysmeta, scimeta, parts):
         super().__init__(client, model, sysmeta, scimeta, parts)
 
     def process(self):
-        logger.debug(f"EML211Processor.process '{self.identifier}'")
+        logger.debug(f"EML210Processor.process '{self.identifier}'")
 
         return super().process()

--- a/d1lod/d1lod/processors/eml/eml220_processor.py
+++ b/d1lod/d1lod/processors/eml/eml220_processor.py
@@ -8,6 +8,11 @@ logger = logging.getLogger(__name__)
 
 
 class EML220Processor(EMLProcessor):
+    """
+    A dataset processor for EML 2.2.0. This processor handles changes to the structured funding
+    and supports annotations.
+    """
+
     def __init__(self, client, model, sysmeta, scimeta, parts):
         super().__init__(client, model, sysmeta, scimeta, parts)
 

--- a/d1lod/tests/data/metadata/eml/eml-200.xml
+++ b/d1lod/tests/data/metadata/eml/eml-200.xml
@@ -1,0 +1,1468 @@
+<?xml version="1.0"?>
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" packageId="connolly.116.1" scope="system" system="knb" xsi:schemaLocation="eml://ecoinformatics.org/eml-2.0.0 eml.xsd">
+  <dataset scope="document">
+      <alternateIdentifier>doi:10.5063/AA/connolly.116.1</alternateIdentifier>
+    <title>Parallel effects of land-use history on species diversity and genetic diversity of forest herbs.</title>
+    <creator id="1104426818453" scope="document">
+      <individualName>
+        <givenName>Mark</givenName>
+        <surName>Vellend</surName>
+      </individualName>
+      <organizationName>National Center for Ecological Analysis and Synthesis</organizationName>
+      <address scope="document">
+        <deliveryPoint>735 State Street, suite 300</deliveryPoint>
+        <city>Santa Barbara</city>
+        <administrativeArea>CA</administrativeArea>
+        <postalCode>93101</postalCode>
+        <country>USA</country>
+      </address>
+      <phone phonetype="voice">(805) 892-2523</phone>
+      <electronicMailAddress>vellend@nceas.ucsb.edu</electronicMailAddress>
+      <onlineUrl>http://www.nceas.ucsb.edu/~vellend/</onlineUrl>
+    </creator>
+      <pubDate>2020-01-01</pubDate>
+    <abstract>
+      <para>The two most fundamental levels of biodiversity, species diversity and genetic diversity, are seldom studied simultaneously despite a strikingly similar set of processes that underlie patterns at the two levels. Agricultural land use drastically reduces populations of forest herbs in the north-temperate zone, so that bottlenecks or founder events in forests on abandoned agricultural land (i.e., secondary forests) may have a long-term impact on both species diversity and genetic diversity. Using forest-herb community surveys and molecular-genetic analysis of populations of Trillium grandiflorum, a representative species of forest herb, I investigated the influence of land-use history, landscape context, and environmental conditions on diversity and divergence at the population and community levels. Secondary forests (70100 years old) had reduced diversity of both genes and species relative to primary forests (i.e., stands never cleared for agriculture). The community in secondary forests had an overrepresentation of the most common species in the landscape, though divergence in species&apos; relative abundances within stands suggested an influence of community drift via local bottlenecks. Secondary-forest populations of T. grandiflorum were more genetically divergent than those in primary forests, again indicating drift in small populations. Land-use history and the size of populations and communities drove correlations between species diversity and genetic diversity (and community divergence &#215; genetic divergence), though the strength of correlations was relatively weak. These results extend the generality of positive speciesgenetic diversity correlations previously observed for islands, and they demonstrate a long-term legacy of land-use history at multiple levels of biodiversity.</para>
+    </abstract>
+    <keywordSet>
+      <keyword>biodiversity; forest herbs; genetic diversity; land-use history; species diversity; Tompkins County, New York (USA); forest stands; Trillium grandiflorum</keyword>
+    </keywordSet>
+    <coverage scope="document">
+      <geographicCoverage scope="document">
+        <geographicDescription>Tompkins County, New York</geographicDescription>
+        <boundingCoordinates>
+          <westBoundingCoordinate>-75.968</westBoundingCoordinate>
+          <eastBoundingCoordinate>-75.892032</eastBoundingCoordinate>
+          <northBoundingCoordinate>43.17</northBoundingCoordinate>
+          <southBoundingCoordinate>43.17</southBoundingCoordinate>
+        </boundingCoordinates>
+      </geographicCoverage>
+      <temporalCoverage scope="document">
+        <rangeOfDates>
+          <beginDate>
+            <calendarDate>2000-01-01</calendarDate>
+          </beginDate>
+          <endDate>
+            <calendarDate>2003-01-01</calendarDate>
+          </endDate>
+        </rangeOfDates>
+      </temporalCoverage>
+    </coverage>
+    <contact scope="document">
+      <references>1104426818453</references>
+    </contact>
+    <methods>
+      <methodStep>
+        <description>
+          <section>
+            <title>Forest stand characteristics</title>
+            <para>During an initial survey of potential study sites, I found 10 isolated secondary forests with T. grandiflorum present, all of which were included in this study.  These stands all occurred on former agricultural fields abandoned sometime before 1938 (the time of the earliest aerial photographs - see Smith et al. 1993), and evidence of pit-and-mound microtopography in some parts of all secondary stands suggested an agricultural history of pasturing, or at least a history that did not include plowing (Marks and Gardescu 2001).  Secondary stands represent a relatively narrow range of areas (1.5-4.4 ha) because larger secondary stands tend to have at least one side adjacent to primary forest.  Stands were chosen so that primary and secondary forests occurred on the same range of soil associations, and a multivariate analysis of variance on three principal components axes extracted from the soil nutrient data showed no significant differences between primary and secondary stands (P &gt; 0.5).  Primary stands were also selected to represent a wide range of areas (0.1-33 ha), encompassing those of secondary stands.  The three smallest primary stands were hedgerows, which function in this landscape as very small elements of primary forest with respect to forest-herb distributions (Corbit et al. 1999).</para>
+          </section>
+        </description>
+      </methodStep>
+      <methodStep>
+        <description>
+          <section>
+            <title>Surveys of vegetation and Trillium populations</title>
+            <para>For the surveys of forest-herb presence within subplots in each stand, larger stands contained six parallel transects; smaller stands (&lt;2 ha) contained 1-5 transects depending on the area and shape of the stand (e.g., plots were placed along one transect down the middle of the hedgerows).</para>
+            <para>During surveys conducted to estimate T. grandiflorum population size, I counted only three-leaved plants (young seedlings have only one leaf and can be difficult to locate amidst other vegetation), and I distinguished reproductive from non-reproductive individuals.  Because estimates of the total number of individuals and the number of reproductives were highly correlated (r = 0.92), in this paper I report only the total population size estimates.  I aimed to count 100 individuals, with overall population size calculated as the mean density within the plots multiplied by the area over which T. grandiflorum was distributed.  When T. grandiflorum was more-or-less evenly distributed throughout larger stands, three 2 &#215; 100 m belt transects were positioned at random along evenly-spaced lines traversing the stand.  If density was high, 8-10 random positions were chosen along each transect, and all individuals were counted in 0.5-2 m2 plots at these positions.  If density was low, all individuals were counted in the entire 2 &#215; 100 m area of each belt transect.  Shorter transects were used in stands where linear dimensions were &lt;100 m.  For stands in which T. grandiflorum was present in only a small area (or areas) of the stand, these areas were delimited, and random 1-m2 plots sampled until at least 100 individuals had been counted.  In the two smallest populations, I counted all the individuals I could find.</para>
+          </section>
+        </description>
+      </methodStep>
+      <methodStep>
+        <description>
+          <section>
+            <title>Allozyme analysis</title>
+            <para>Following field collection, leaf samples were stored at 4oC for no more than 4 days prior to processing for genetic analysis.  Half of each sample was ground with mortar and pestle in an extraction buffer with 0.2 M Tris HCl, 0.7 mM Borax, 4 mM sodium metabisulfite, 40 mM sodium diethyldithiocarbonate, 50 mM sodium ascorbate, 11 mM DTT, and 3 mM PVP-40 (Griffin and Barrett 2004).  The resulting extract was absorbed onto filter paper wicks, and frozen at -80oC prior to electrophoresis.  Allozyme variation was assayed at four loci in all 40 individuals per population using standard methods of starch gel electrophoresis and specific enzyme activity staining (Wendel and Weeden 1989).  Malate dehydrogenase (MDH), phosphogluconate dehydrogenase (PGD), and phosphoglucoseisomerase (PGI) were run on a morpholine citrate gel system at pH 6.1 (Wendel and Weeden system no. 2), and menadione reductase (MNR) was run on lithium borate - tris citrate gel system (Wendel and Weeden system no. 6; see also Broyles et al. 1997).</para>
+          </section>
+        </description>
+      </methodStep>
+      <methodStep>
+        <description>
+          <section>
+            <title>Chloroplast DNA analysis</title>
+            <para>One region of the T. grandiflorum cpDNA genome (~2.4 kbp) was amplified using the trnH-trnK primer pair from Demesure et al. (1995).  The PCR product for each individual was digested separately with two restriction enzymes, AluI and MspI (New England BioLabs, Inc., Beverly, Massachusetts, USA), and the resulting fragments were run out on 1.5% agarose gels.  DNA fragments revealing one length polymorphism (best seen with AluI-created fragments), and one restriction site polymorphism (MspI), were visualized by staining the gels with Ethidium Bromide, and viewing under UV radiation (see also Griffin and Barrett 2004).</para>
+          </section>
+        </description>
+      </methodStep>
+      <methodStep>
+        <description>
+          <section>
+            <title>Soil nutrient analysis</title>
+            <para>The sensitivity of the soil NO3- and NH4+ analyses was insufficient for detection in the forests sampled in this study, though a previous, more sensitive analysis indicated that NO3- and NH4+ were strongly correlated with the first principal component axis describing variation in the same soil variables across a range of forest sites in Tompkins County (|r| &gt; 0.7; K. M. Flinn, M. Vellend, and P. L. Marks, unpublished data).  NO3- and NH4+ were not included in the principal components analysis of soil data in this study.</para>
+            <para>The degree of soil drainage at each site was scored on a scale from 14: very poor, poor, moderate, and well-drained, respectively, using a digital map (Tompkins County Planning Department 2000) and descriptions (Neeley 1965) of soil associations in Tompkins County.  When more than one soil association occurred at a given site, a weighted average (based on area) was calculated as the site level drainage value.</para>
+            <para>Prior to the PCA of soil data, all variables except pH, loss-on-ignition and drainage were either log- or square root-transformed to reduce skew in their distributions.  The first two PCA axes were rotated using the VARIMAX method (SAS PROC FACTOR) to maximally align variables with PCA axes.  Axis I was strongly correlated with pH (r = 0.96), Ca (0.89), Mg (0.83), Cu (0.75), Al (-0.97), Fe (-0.87), and Zn (-0.77).  Axis II had moderate to strong correlations with drainage (-0.59) and LOI (0.82).</para>
+          </section>
+        </description>
+      </methodStep>
+      <methodStep>
+        <description>
+          <section>
+            <title>LITERATURE CITED IN METHODS</title>
+            <para>Broyles, S. B., S. L. Sherman-Broyles, and P. Rogati. 1997. Evidence of outcrossing in Trillium erectum and Trillium grandiflorum (Liliaceae). Journal of Heredity 88:325-359.</para>
+            <para>Corbit, M., P. L. Marks, and S. Gardescu. 1999. Hedgerows as habitat corridors for forest herbs in central New York, USA. Journal of Ecology 87:220-232.</para>
+            <para>Gleason, H. A., and A. Cronquist. 1991. Manual of vascular plants of northeastern United States and adjacent Canada, Second edition. New York Botanical Garden, New York, New York, USA.</para>
+            <para>Griffin, S. R., and S. C. H. Barrett. 2004. Post-glacial history of Trillium grandiflorum (Melianthiaceae) in eastern North America: inferences from phylogeography. American Journal of Botany, in press.</para>
+            <para>Hanzawa, F. M., and S. Kalisz 1993. The relationship between age, size and reproduction in Trillium grandiflorum (Liliaceae). American Journal of Botany 80:405-410.</para>
+            <para>Irwin, R. E. 2000. Morphological variation and female reproductive success in two sympatric Trillium species: evidence for phenotypic selection in Trillium erectum and Trillium grandiflorum (Liliaceae). American Journal of Botany 87:205-214.</para>
+            <para>Marks, P.L., and S. Gardescu. 2001. Inferring forest stand history from observational field evidence. Pages 177-198 in D. Egan, and E. A. Howell, editors. The historical ecology handbook: a restorationist&apos;s guide to reference ecosystems. Island Press, Washington, DC, USA.</para>
+            <para>Neeley, J. A. 1965. Soil survey, Tompkins County, New York.  Series 1961, No. 25. USDA Soil Conservation Service, Government Printing Office, Washington, DC, USA.</para>
+            <para>Sage, T. L., S. R. Griffin, V. Pontieri, P. Drobac, W. W. Cole, and S. C. H. Barrett. 2001. Stigmatic self-incompatibility and mating patterns in Trillium grandiflorum and Trillium erectum (Melianthiaceae). Annals of Botany 88:829-841.</para>
+            <para>Smith, B. E., P. L. Marks, and S. Gardescu. 1993. Two hundred years of forest cover changes in Tompkins County, New York. Bulletin of the Torrey Botanical Club 120:223-247.</para>
+            <para>Tompkins County Planning Department. 2000. Soil Associations (ARC Export 1965). Tompkins County ITS GIS Division, Tompkins County Planning Department, Ithaca, New York, USA.</para>
+            <para>Vellend, M., J. A. Myers, S. Gardescu, and P. L. Marks. 2003. Dispersal of Trillium seeds by deer: implications for long distance migration of forest herbs. Ecology 84:1067-1072.</para>
+            <para>Wendel, J. F., and N. F. Weeden. 1989. Visualisation and interpretation of plant isozymes. Pages 46-72 in D. E. Soltis, and P. S. Soltis, editors. Isozymes in plant biology. Dioscorides Press, Portland, Oregon, USA.</para>
+          </section>
+        </description>
+      </methodStep>
+      <methodStep>
+        <description>
+          <section>
+            <title>Isolation and characterization of microsatellite DNA markers in Trillium grandiflorum.</title>
+            <para>Given the relatively small number of alleles found at allozyme loci and in chloroplast DNA analyses, I developed microsatellite loci for assaying genetic variation in Trillium grandiflorum.  All analyses described here were conducted under the guidance of Steven Bogdanowicz (Department of Ecology and Evolutionary Biology, Cornell University, Ithaca, New York, USA).</para>
+            <para>DNA extraction from &lt; 0.1 g of leaf tissue per individual was conducted using the QIAGEN DNeasy plant mini kit (QIAGEN Inc., Valencia, California, USA).  Trillium grandiflorum genomic DNA from three individuals was first digested with HincII and RsaI, and a double-stranded SNX linker (Hamilton et al. 1999) was ligated to the ends of the genomic fragments in a one-step digestion/ligation reaction.  The genomic fragments were then hybridized to biotinylated repetitive probes to enrich for microsatellite loci, and products of this hybridization were captured with streptavidin-coated magnetic beads and a magnet (Hamilton et al. 1999).  Polymerase chain reaction (PCR) was conducted (using the SNX forward primer) on the resulting DNA fragments, which were subsequently digested with NheI prior to ligation into the plasmid pUC 19.  Competent E. coli (Life Technologies Max Efficiency DH5a) were transformed with the NheI-trimmed pUC 19 ligation, and plated out on LB/ampicillin agar.  E. coli colonies were then lifted with Magna Graph membranes (Osmonics, Inc.) and screened with 33P-labelled synthetic repeats (CT)12 and (GT)12.  Thirty clones with positive signals were amplified with M13 forward and reverse primers and sequenced with M13 forward primer and a BigDye Terminator Cycle Sequencing Kit and an ABI 377 automated sequencer (Applied Biosystems, Foster City, California, USA).  Primers were designed for 10 loci, eight of which produced reliable amplification products in a sample of eight individuals.  Dye-labeled primers were purchased for all eight loci; one of these showed no variation, and four of them revealed uninterpretable banding patterns.  For the remaining three loci (Table 1), variation in at least 20 individuals from all populations was scored.</para>
+            <para>Microsatellite loci were amplified using PCR in a PTC-100TM Programmable Thermal Controller (M. J. Research Inc., Waltham, Massachusetts, USA) in 10 mL reactions, containing 1&#181;L genomic DNA, 1&#215; PCR Buffer (10 mM Tris-HCL, 1.5 mM MgCl2, 50 mM KCl, pH 8.3), 0.25 mM each dNTP, 2 pmol of each primer, and 0.25 units Taq polymerase (Roche Diagnostics, Mannheim, Germany).  Amplification cycle conditions consisted of 5 min at 95 &#176;C, and then cycles of 50 s at 95 &#176;C, 1 min at annealing temperature (Table 1, and see below), 1 min at 72 &#176;C, and then a final extension step for 5 min at 72 &#176;C.  All three loci were amplified using &quot;touchdown&quot; PCR (Don et al. 1991), with the annealing temperature started 9oC above the optimum, and then reduced 1oC per cycle until the optimum had been reached.  PCR was continued for 33 cycles at the optimal annealing temperature (Table 1), and PCR products were separated in an ABI 377 automated sequencer.</para>
+            <para>Genotyper software (Applied Biosystems) was used to score allele sizes relative to size standards (GeneScan-500 ROX Size Standard, Applied Biosystems).  One locus (8) showed evidence of null alleles in that it failed to amplify in 12% of the individuals screened, and analysis of the remaining data showed far greater deviations from Hardy-Weinberg equilibrium than the other two loci.  For all putative null-allele homozygotes at this locus, PCR amplification was attempted twice; if amplification was unsuccessful both times, but successful for the other two loci, the individual in question was scored as a null-allele homozygote.</para>
+            <para>A total of 26 alleles were observed across the three loci, with nine each in loci 44 and 51, and eight in locus 8 (including the null allele).  Differences in allele sizes were all multiples of two base pairs - consistent with differences in the number of dinucleotide repeats.</para>
+            <para>To test for the importance of microsatellite allele sizes in determining measures of genetic differentiation among populations, I used the test described in Hardy et al. (2003), and implemented in SPAGeDi 1.1 (Hardy and Vekemans 2002).  The null allele at locus 8 was not included in this analysis because its size is unknown.  If the rate of stepwise mutation within populations is sufficiently large relative to the rate of immigration, the size of microsatellite alleles may contribute important information to measures of genetic differentiation.  The Hardy et al. (2003) test repeatedly randomizes allele sizes among alleles in the data set, and recalculates RST each time (RST is an analogue of FST as a measure of genetic differentiation that incorporates information on allele sizes).  If the observed RST is larger or smaller than the extremes of the simulated RST distribution ( = 0.05), then allele size contributes important information to genetic differentiation.  For all three loci, there was no evidence that allele sizes were important, suggesting (not surprisingly) that the migration rate among populations within a relatively small area (a single county) exceeds the mutation rate.</para>
+            <para>LITERATURE CITED</para>
+            <para>Don, R. H., P. T. Cox, B. J. Wainwright, K. Baker, and J. S. Mattick. 1991. Touchdown PCR to circumvent spurious priming during gene amplification. Nucleic Acids Research 19:4008.</para>
+            <para>Hamilton, M. B., E. L. Pincus, A. De Fiore, and R. C. Fleischer. 1999. Universal linker and ligation procedures for construction of genomic DNA libraries enriches for microsatellites. BioTechniques 27:500-507.</para>
+            <para>Hardy, O. J., and X. Vekemans 2002. SPAGeDi : a versatile computer program to analyse spatial genetic structure at the individual or population levels. Molecular Ecology Notes 2:618-620.</para>
+            <para>Hardy, O. J., N. Charbonnel, H. Fr&#233;ville and M. Heuertz. 2003. Microsatellite allele sizes: a simple test to assess their significance on genetic differentiation. Genetics 163:1467-1482.</para>
+          </section>
+        </description>
+      </methodStep>
+    </methods>
+    <access authSystem="knb" order="denyFirst" scope="document">
+      <allow>
+        <principal>public</principal>
+        <permission>read</permission>
+      </allow>
+      <allow>
+        <principal>uid=connolly,o=NCEAS,dc=ecoinformatics,dc=org</principal>
+        <permission>all</permission>
+      </allow>
+    </access>
+    <dataTable id="1104781222714" scope="document">
+      <entityName>Species diversity and divergence, genetic diversity and divergence, landscape attributes, and environmental conditions</entityName>
+      <entityDescription>Summary measures of species diversity and divergence, genetic diversity and divergence, landscape attributes, and environmental conditions in 27 forest stands in Tompkins County, New York.</entityDescription>
+      <physical id="1104781221448" scope="document">
+        <objectName>AppendixE.txt</objectName>
+        <size unit="byte">2141</size>
+        <dataFormat>
+          <textFormat>
+            <numHeaderLines>1</numHeaderLines>
+            <recordDelimiter>#x0A</recordDelimiter>
+            <attributeOrientation>column</attributeOrientation>
+            <simpleDelimited>
+              <fieldDelimiter>#x09</fieldDelimiter>
+            </simpleDelimited>
+          </textFormat>
+        </dataFormat>
+        <distribution scope="document">
+          <online>
+            <url function="download">ecogrid://knb/connolly.104.1</url>
+          </online>
+        </distribution>
+      </physical>
+      <attributeList>
+        <attribute id="1104781222729" scope="document">
+          <attributeName>Stand</attributeName>
+          <attributeLabel>Stand identification</attributeLabel>
+          <attributeDefinition>Identification of stand surveyed.</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>1A-Q: primary stands. 2A-J: secondary stands.</definition>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222745" scope="document">
+          <attributeName>L-U history</attributeName>
+          <attributeLabel>Land-use history</attributeLabel>
+          <attributeDefinition>Land-use history of stand surveyed.</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <enumeratedDomain enforced="yes">
+                  <codeDefinition>
+                    <code>P</code>
+                    <definition>Primary forest</definition>
+                  </codeDefinition>
+                  <codeDefinition>
+                    <code>S</code>
+                    <definition>Secondary forest (70-100 years old)</definition>
+                  </codeDefinition>
+                </enumeratedDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222761" scope="document">
+          <attributeName>Sp. richness</attributeName>
+          <attributeLabel>Species richness</attributeLabel>
+          <attributeDefinition>The number of species observed in a given forest stand.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <customUnit>species</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222776" scope="document">
+          <attributeName>Evenness</attributeName>
+          <attributeLabel>Evenness</attributeLabel>
+          <attributeDefinition>The probability that two randomly chosen occurrences in a given stand are of different species.  An occurrence is the presence of a species in one of thirty 25m2 circular plots surveyed in each stand.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222792" scope="document">
+          <attributeName>BRC</attributeName>
+          <attributeLabel>Presence-absence based community divergence</attributeLabel>
+          <attributeDefinition>The probability that a pair of stands shares fewer species in common than would be expected at random.  A given stand is characterized by its mean value in pairwise comparisons with all other stands.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222808" scope="document">
+          <attributeName>FST-C</attributeName>
+          <attributeLabel>Frequency-based community divergence</attributeLabel>
+          <attributeDefinition>If He is calculated using mean species relative frequencies across a given pair of populations, FST-C is the proportion of that value of He attributable to differences in species relative frequencies between populations.  A given population is characterized by its mean value in pairwise comparisons with all other populations.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222823" scope="document">
+          <attributeName>AR</attributeName>
+          <attributeLabel>Allelic richness</attributeLabel>
+          <attributeDefinition>The number of alleles or haplotypes observed across all molecular markers in a population, corrected for differences in sample size among populations.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <customUnit>allele/haplotype</customUnit>
+              </unit>
+              <precision>0.1</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222839" scope="document">
+          <attributeName>He</attributeName>
+          <attributeLabel>Expected heterozygosity</attributeLabel>
+          <attributeDefinition>The mean across markers of the probability that two randomly chosen alleles or haplotypes within a population are different.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222854" scope="document">
+          <attributeName>FST-G</attributeName>
+          <attributeLabel>Genetic divergence</attributeLabel>
+          <attributeDefinition>If He is calculated using mean allele/haplotype frequencies across a given pair of populations, FST-G is the proportion of that value of He attributable to differences in allele/haplotype frequencies between populations.  A given population is characterized by its mean value in pairwise comparisons with all other populations.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.001</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222870" scope="document">
+          <attributeName>Area</attributeName>
+          <attributeLabel>Stand area</attributeLabel>
+          <attributeDefinition>Area of surveyed stand determined using 1995 aerial photographs in ArcView 8.1.2 (ESRI, Redlands, California).</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>hectare</standardUnit>
+              </unit>
+              <precision>0.1</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222886" scope="document">
+          <attributeName>Pop. size</attributeName>
+          <attributeLabel>Population size</attributeLabel>
+          <attributeDefinition>Number of Trillium grandiflorum individuals. Population size of Trillium grandiflorum was estimated by counting individuals in a sample of plots from each stand, with the number and arrangement of plots tailored to the spatial distribution and density of individuals, and extrapolating to the stand scale.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>individuals</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222901" scope="document">
+          <attributeName>pH</attributeName>
+          <attributeLabel>pH</attributeLabel>
+          <attributeDefinition>The pH value of a bulked soil sample from each stand.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222917" scope="document">
+          <attributeName>PCA1</attributeName>
+          <attributeLabel>PCA1 (pH)</attributeLabel>
+          <attributeDefinition>Value on Axis 1 of a principal component analysis of soil variables.  Axis 1 represented a soil pH gradient (explaining 49% of the variation in the data).</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222933" scope="document">
+          <attributeName>PCA2</attributeName>
+          <attributeLabel>PCA2 (drainage)</attributeLabel>
+          <attributeDefinition>Value on Axis 2 of a principal component analysis of soil variables.  Axis 2 appeared to represent a soil moisture gradient (18% of the variation  in the data).</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222948" scope="document">
+          <attributeName>Isolation</attributeName>
+          <attributeLabel>Isolation</attributeLabel>
+          <attributeDefinition>The relative isolation of each stand from potential sources of colonists was estimated by first creating buffers of 100m, 200m, 500m, and 1km around each stand in ArcView 8.1.2 (ESRI, Redlands, California).  Within each of four resulting zones (0-100m, 100-200m, etc.), the proportion of the landscape in primary forest was estimated.  A weighted average of these four proportions was then calculated as a measure of connectivity, with weights determined by the square of the distance from stand edge to the mid-point of each zone (i.e., 50m, 150m, etc.).  The negative logarithm of these values was used as a measure of isolation (the log transformation reduced considerable skew in the distribution).</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <customUnit>log</customUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104781222964" scope="document">
+          <attributeName>Env. Het.</attributeName>
+          <attributeLabel>Environmental heterogeneity</attributeLabel>
+          <attributeDefinition>Index of environmental heterogeneity calculated as the standard deviation of the slope angle among 10x10m portions of each stand.  Slope angle was estimated in ArcView 8.1.2 (ESRI, Redlands, California). using a digital elevation model for Tompkins County with a resolution of 10x10m.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+      </attributeList>
+      <numberOfRecords>27</numberOfRecords>
+    </dataTable>
+    <dataTable id="1104790950859" scope="document">
+      <entityName>Forest-herb community data</entityName>
+      <entityDescription>Forest-herb community data in 17 primary (A) and 10 secondary (B) forest stands in Tompkins County, New York.  Cells indicate the number of circular plots (25m2) out of 30 per stand in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances (i.e., evenness and frequency-based community divergence).  Where more than one species is listed in a row, these species were not distinguishable in the field. * species only observable during spring (no plot-based data). ** species observed in plots but not during stand-level search (surveys conducted on different days); these observations were not included in calculations based on presence-absence data (i.e., species richness and presence-absence based community divergence). Nomenclature follows Gleason, H. A., and A. Cronquist. 1991. Manual of vascular plants of northeastern United States and adjacent Canada, Second edition. New York Botanical Garden, New York, New York, USA.</entityDescription>
+      <physical id="1104790949890" scope="document">
+        <objectName>AppendixC-1.txt</objectName>
+        <size unit="byte">6249</size>
+        <dataFormat>
+          <textFormat>
+            <numHeaderLines>1</numHeaderLines>
+            <recordDelimiter>#x0A</recordDelimiter>
+            <attributeOrientation>column</attributeOrientation>
+            <simpleDelimited>
+              <fieldDelimiter>#x09</fieldDelimiter>
+            </simpleDelimited>
+          </textFormat>
+        </dataFormat>
+        <distribution scope="document">
+          <online>
+            <url function="download">ecogrid://knb/connolly.102.1</url>
+          </online>
+        </distribution>
+      </physical>
+      <attributeList>
+        <attribute id="1104790950875" scope="document">
+          <attributeName>Species</attributeName>
+          <attributeLabel>Species</attributeLabel>
+          <attributeDefinition>Name of species found in stand.</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>Species name</definition>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790950890" scope="document">
+          <attributeName>1A</attributeName>
+          <attributeLabel>Stand 1A</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1A in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790950906" scope="document">
+          <attributeName>1B</attributeName>
+          <attributeLabel>Stand 1B</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1B in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790950921" scope="document">
+          <attributeName>1C</attributeName>
+          <attributeLabel>Stand 1C</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1C in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790950937" scope="document">
+          <attributeName>1D</attributeName>
+          <attributeLabel>Stand 1D</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1D in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790950953" scope="document">
+          <attributeName>1E</attributeName>
+          <attributeLabel>Stand 1E</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1E in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790950968" scope="document">
+          <attributeName>1F</attributeName>
+          <attributeLabel>Stand 1F</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1F in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790950984" scope="document">
+          <attributeName>1G</attributeName>
+          <attributeLabel>Stand 1G</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1G in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951000" scope="document">
+          <attributeName>1H</attributeName>
+          <attributeLabel>Stand 1H</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1H in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951015" scope="document">
+          <attributeName>1I</attributeName>
+          <attributeLabel>Stand 1I</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1I in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951031" scope="document">
+          <attributeName>1J</attributeName>
+          <attributeLabel>Stand 1J</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1J in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951046" scope="document">
+          <attributeName>1K</attributeName>
+          <attributeLabel>Stand 1K</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1K in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951062" scope="document">
+          <attributeName>1L</attributeName>
+          <attributeLabel>Stand 1L</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1L in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951078" scope="document">
+          <attributeName>1M</attributeName>
+          <attributeLabel>Stand 1M</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1M in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951093" scope="document">
+          <attributeName>1N</attributeName>
+          <attributeLabel>Stand 1N</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1N in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951109" scope="document">
+          <attributeName>1O</attributeName>
+          <attributeLabel>Stand 1O</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1O in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951125" scope="document">
+          <attributeName>1P</attributeName>
+          <attributeLabel>Stand 1P</attributeLabel>
+          <attributeDefinition>No plot-based data were taken in this stand. A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951140" scope="document">
+          <attributeName>1Q</attributeName>
+          <attributeLabel>Stand 1Q</attributeLabel>
+          <attributeDefinition>Number of plots within stand 1Q in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951156" scope="document">
+          <attributeName>2A</attributeName>
+          <attributeLabel>Stand 2A</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2A in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951171" scope="document">
+          <attributeName>2B</attributeName>
+          <attributeLabel>Stand 2B</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2B in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951187" scope="document">
+          <attributeName>2C</attributeName>
+          <attributeLabel>Stand 2C</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2C in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951203" scope="document">
+          <attributeName>2D</attributeName>
+          <attributeLabel>Stand 2D</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2D in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951218" scope="document">
+          <attributeName>2E</attributeName>
+          <attributeLabel>Stand 2E</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2E in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951234" scope="document">
+          <attributeName>2F</attributeName>
+          <attributeLabel>Stand 2F</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2F in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951250" scope="document">
+          <attributeName>2G</attributeName>
+          <attributeLabel>Stand 2G</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2G in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951265" scope="document">
+          <attributeName>2H</attributeName>
+          <attributeLabel>Stand 2H</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2H in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951281" scope="document">
+          <attributeName>2I</attributeName>
+          <attributeLabel>Stand 2I</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2I in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104790951296" scope="document">
+          <attributeName>2J</attributeName>
+          <attributeLabel>Stand 2J</attributeLabel>
+          <attributeDefinition>Number of plots within stand 2J in which each species was found.  A value of 0.1 indicates that the species was found during the full-stand survey of species&apos; presence-absence, but not in the plots; these species were not included in any calculations based on species&apos; relative abundances.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>plot</customUnit>
+              </unit>
+              <precision>1</precision>
+              <numericDomain>
+                <numberType>whole</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+      </attributeList>
+      <numberOfRecords>74</numberOfRecords>
+    </dataTable>
+    <dataTable id="1104862609125" scope="document">
+      <entityName>Frequencies of alleles and haplotypes</entityName>
+      <entityDescription>Frequencies of alleles and haplotypes for molecular marker loci in 17 primary (A) and 10 secondary (B) populations of Trillium grandiflorum in Tompkins County, New York.</entityDescription>
+      <physical id="1104862608109" scope="document">
+        <objectName>AppendixD-1.txt</objectName>
+        <size unit="byte">4733</size>
+        <dataFormat>
+          <textFormat>
+            <numHeaderLines>1</numHeaderLines>
+            <recordDelimiter>#x0A</recordDelimiter>
+            <attributeOrientation>column</attributeOrientation>
+            <simpleDelimited>
+              <fieldDelimiter>#x09</fieldDelimiter>
+            </simpleDelimited>
+          </textFormat>
+        </dataFormat>
+        <distribution scope="document">
+          <online>
+            <url function="download">ecogrid://knb/connolly.105.1</url>
+          </online>
+        </distribution>
+      </physical>
+      <attributeList>
+        <attribute id="1104862609140" scope="document">
+          <attributeName>Locus</attributeName>
+          <attributeLabel>Locus</attributeLabel>
+          <attributeDefinition>Name of locus</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>Name of locus</definition>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609156" scope="document">
+          <attributeName>Allele/Haplotype</attributeName>
+          <attributeLabel>Allele/Haplotype</attributeLabel>
+          <attributeDefinition>Allele/haplotype name. S or F refer to a difference in size of a ~250bp DNA fragment produced when the HK region is cut with AluI; the larger fragment runs &quot;Slow&quot;, the smaller one &quot;Fast&quot;.  A or B refers to the presence (A) or absence (B) of a restriction site cut by MspI.
+Microsatellite allele names indicate their size (bp).</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>Allele/Haplotype</definition>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609171" scope="document">
+          <attributeName>1A</attributeName>
+          <attributeLabel>Stand 1A</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1A.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609187" scope="document">
+          <attributeName>1B</attributeName>
+          <attributeLabel>Stand 1B</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1B.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609203" scope="document">
+          <attributeName>1C</attributeName>
+          <attributeLabel>Stand 1C</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1C.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609218" scope="document">
+          <attributeName>1D</attributeName>
+          <attributeLabel>Stand 1D</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1D.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609234" scope="document">
+          <attributeName>1E</attributeName>
+          <attributeLabel>Stand 1E</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1E.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609250" scope="document">
+          <attributeName>1F</attributeName>
+          <attributeLabel>Stand 1F</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1F.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609265" scope="document">
+          <attributeName>1G</attributeName>
+          <attributeLabel>Stand 1G</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1G.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609281" scope="document">
+          <attributeName>1H</attributeName>
+          <attributeLabel>Stand 1H</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1H.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609296" scope="document">
+          <attributeName>1I</attributeName>
+          <attributeLabel>Stand 1I</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1I.</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609312" scope="document">
+          <attributeName>1J</attributeName>
+          <attributeLabel>Stand 1J</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1J.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609328" scope="document">
+          <attributeName>1K</attributeName>
+          <attributeLabel>Stand 1K</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1K.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609343" scope="document">
+          <attributeName>1L</attributeName>
+          <attributeLabel>Stand 1L</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1L.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609359" scope="document">
+          <attributeName>1M</attributeName>
+          <attributeLabel>Stand 1M</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1M.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609375" scope="document">
+          <attributeName>1N</attributeName>
+          <attributeLabel>Stand 1N</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1N.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609390" scope="document">
+          <attributeName>1O</attributeName>
+          <attributeLabel>Stand 1O</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1O.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609406" scope="document">
+          <attributeName>1P</attributeName>
+          <attributeLabel>Stand 1P</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1P.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609421" scope="document">
+          <attributeName>1Q</attributeName>
+          <attributeLabel>Stand 1Q</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 1Q.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609437" scope="document">
+          <attributeName>2A</attributeName>
+          <attributeLabel>Stand 2A</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2A.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609453" scope="document">
+          <attributeName>2B</attributeName>
+          <attributeLabel>Stand 2B</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2B.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609468" scope="document">
+          <attributeName>2C</attributeName>
+          <attributeLabel>Stand 2C</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2C.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609484" scope="document">
+          <attributeName>2D</attributeName>
+          <attributeLabel>Stand 2D</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2D.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609500" scope="document">
+          <attributeName>2E</attributeName>
+          <attributeLabel>Stand 2E</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2E.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609515" scope="document">
+          <attributeName>2F</attributeName>
+          <attributeLabel>Stand 2F</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2F.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609531" scope="document">
+          <attributeName>2G</attributeName>
+          <attributeLabel>Stand 2G</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2G.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609546" scope="document">
+          <attributeName>2H</attributeName>
+          <attributeLabel>Stand 2H</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2H.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609562" scope="document">
+          <attributeName>2I</attributeName>
+          <attributeLabel>Stand 2I</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2I.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+        <attribute id="1104862609578" scope="document">
+          <attributeName>2J</attributeName>
+          <attributeLabel>Stand 2J</attributeLabel>
+          <attributeDefinition>Frequencies of alleles and haplotypes in stand 2J.</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>dimensionless</standardUnit>
+              </unit>
+              <precision>0.01</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+        </attribute>
+      </attributeList>
+      <numberOfRecords>42</numberOfRecords>
+    </dataTable>
+    <dataTable id="1104865024828" scope="document">
+      <entityName>Table 1 (see Step 7 of Methods)</entityName>
+      <entityDescription>Characteristics of three microsatellite loci in Trillium grandiflorum.  &quot;Acc&apos;n&quot; refers to the GenBank accession number, and Ta is the PCR annealing temperature.  The top primer in each pair was dye-labeled for visualization in genotyping.</entityDescription>
+      <physical scope="document">
+        <objectName>Microsatellite loci in TG.jpg</objectName>
+        <dataFormat>
+          <externallyDefinedFormat>
+            <formatName>jpeg</formatName>
+          </externallyDefinedFormat>
+        </dataFormat>
+        <distribution scope="document">
+          <online>
+            <url function="download">ecogrid://knb/connolly.106.1</url>
+          </online>
+        </distribution>
+      </physical>
+      <attributeList>
+        <attribute id="1104865024843" scope="document">
+          <attributeName>Locus, Acc&apos;n</attributeName>
+          <attributeLabel>Locus and accession number</attributeLabel>
+          <attributeDefinition>Locus number and GenBank accession number.</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>Locus number and GenBank accession number.</definition>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+        </attribute>
+      </attributeList>
+    </dataTable>
+  </dataset>
+  <additionalMetadata>
+    <unitList>
+      <unit id="log" name="log" parentSI="mole" unitType="amount">
+        <description>Logarithmic function</description>
+      </unit>
+    </unitList>
+  </additionalMetadata>
+  <additionalMetadata>
+    <unitList>
+      <unit id="species" name="species" parentSI="mole" unitType="amount">
+        <description>Number of species</description>
+      </unit>
+    </unitList>
+  </additionalMetadata>
+  <additionalMetadata>
+    <unitList>
+      <unit id="allele/haplotype" name="allele or haplotype" parentSI="mole" unitType="amount">
+        <description>allele or haplotype</description>
+      </unit>
+    </unitList>
+  </additionalMetadata>
+  <additionalMetadata>
+    <unitList>
+      <unit id="individuals" name="individuals" parentSI="mole" unitType="amount">
+        <description>individuals</description>
+      </unit>
+    </unitList>
+  </additionalMetadata>
+  <additionalMetadata>
+    <unitList>
+      <unit id="log1" name="log" parentSI="number" unitType="dimensionless">
+        <description>logarithmic value</description>
+      </unit>
+    </unitList>
+  </additionalMetadata>
+  <additionalMetadata>
+    <unitList>
+      <unit id="plot" name="plot" parentSI="mole" unitType="amount">
+        <description>number of plot</description>
+      </unit>
+    </unitList>
+  </additionalMetadata>
+</eml:eml>

--- a/d1lod/tests/data/metadata/eml/eml-201.xml
+++ b/d1lod/tests/data/metadata/eml/eml-201.xml
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eml:eml packageId="ICMDXX_XXXITV2XMSR01_20170101.50.1" scope="system"
+  system="knb" xmlns:eml="eml://ecoinformatics.org/eml-2.0.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eml://ecoinformatics.org/eml-2.0.1 eml.xsd">
+  <dataset scope="document">
+    <alternateIdentifier>doi:10.6085/AA/ICMDXX_XXXITV2XMSR01_20170101.50.1</alternateIdentifier>
+    <shortName>MARINe/PISCO intertidal site temperature, ICMDXX</shortName>
+    <title>MARINe/PISCO: Intertidal: site temperature data: Cape Mendocino (ICMDXX)</title>
+    <creator scope="document">
+      <organizationName>Multi-Agency Rocky Intertidal Network (MARINe)</organizationName>
+      <onlineUrl>https://pacificrockyintertidal.org</onlineUrl>
+    </creator>
+    <creator scope="document">
+      <organizationName>Partnership for Interdisciplinary Studies of Coastal Oceans (PISCO)</organizationName>
+      <onlineUrl>http://www.piscoweb.org</onlineUrl>
+    </creator>
+    <creator scope="document">
+      <individualName>
+        <salutation>Dr.</salutation>
+        <givenName>Pete</givenName>
+        <surName>Raimondi</surName>
+      </individualName>
+      <address scope="document">
+        <deliveryPoint>University of California, Santa Cruz, Long Marine Lab</deliveryPoint>
+        <deliveryPoint>115 McAllister Way</deliveryPoint>
+        <city>Santa Cruz</city>
+        <administrativeArea>CA</administrativeArea>
+        <postalCode>95060</postalCode>
+        <country>USA</country>
+      </address>
+      <electronicMailAddress>raimondi@ucsc.edu</electronicMailAddress>
+    </creator>
+    <associatedParty scope="document">
+      <individualName>
+        <salutation>Dr.</salutation>
+        <givenName>Dave</givenName>
+        <surName>Lohse</surName>
+      </individualName>
+      <address scope="document">
+        <deliveryPoint>University of California, Santa Cruz, Long Marine Lab</deliveryPoint>
+        <deliveryPoint>115 McAllister Way</deliveryPoint>
+        <city>Santa Cruz</city>
+        <administrativeArea>CA</administrativeArea>
+        <postalCode>95060</postalCode>
+        <country>USA</country>
+      </address>
+      <phone phonetype="fax">(831) 459-3383</phone>
+      <electronicMailAddress>dlohse@ucsc.edu</electronicMailAddress>
+      <role>Assistant Investigator</role>
+    </associatedParty>
+    <language>English</language>
+    <series>ICMDXX_XXXITV2XMSR01_20170101</series>
+    <pubDate>2019-09-26</pubDate>
+    <abstract>
+      <para>This metadata record describes a mix of intertidal seawater and air temperature data collected at Cape Mendocino by MARINe/PISCO. Measurements were collected using Temperature Loggers from Onset Computer Corp</para>
+    </abstract>
+    <keywordSet>
+      <keyword>EARTH SCIENCE : Oceans : Ocean Temperature : Water Temperature</keyword>
+      <keywordThesaurus>Global Change Master Directory</keywordThesaurus>
+    </keywordSet>
+    <keywordSet>
+      <keyword>Temperature</keyword>
+      <keyword>Integrated Ocean Observing System</keyword>
+      <keyword>IOOS</keyword>
+      <keywordThesaurus>IOOS Vocabulary Version 1</keywordThesaurus>
+    </keywordSet>
+    <keywordSet>
+      <keyword>Oceanographic Sensor Data</keyword>
+      <keyword>Intertidal Temperature Data</keyword>
+      <keywordThesaurus>PISCO Categories</keywordThesaurus>
+    </keywordSet>
+    <keywordSet>
+      <keyword>continental shelf</keyword>
+      <keyword>seawater</keyword>
+      <keyword>temperature</keyword>
+      <keyword>Northern California</keyword>
+      <keyword>United States of America</keyword>
+      <keyword>PISCO</keyword>
+      <keyword>MARINe</keyword>
+    </keywordSet>
+    <intellectualRights>
+      <para>We encourage collaborative (co-authorship) efforts with MARINe scientists, and request that you discuss your analyses with us to minimize duplicative efforts and ensure that you are aware of any data oddities that might affect your results. Please provide us with copies of any data products that result from use of these data. Please acknowledge MARINe in all publications containing these data. Because MARINe is a consortium of different groups, please also acknowledge the research groups that collected these data and the funding groups associated with these data, by using a statement similar to the following: This study utilized data collected by the Multi-Agency Rocky Intertidal Network (MARINe): a long-term ecological consortium funded and supported by many groups. Please visit pacificrockyintertidal.org for a complete list of the MARINe partners responsible for monitoring and funding these data. Data management has been primarily supported by BOEM (Bureau of Ocean Energy Management), NPS (National Park Service), The David and Lucile Packard Foundation, and United States Navy. </para>
+      <para>Please send copies of any published manuscript based on these data to the MARINe Program Coordinator (pacificr@ucsc.edu) and the PISCO Program Coordinator (PISCO-contact@lists.oregonstate.edu). Extensive efforts are made to ensure that online data are accurate and up to date, but the authors and MARINe will not take responsibility for any errors that may exist in data provided online. Furthermore, the user assumes all responsibility for errors in analysis or judgement resulting from use of the data.</para>
+    </intellectualRights>
+    <distribution scope="document">
+      <online>
+        <url function="information">https://pacificrockyintertidal.org</url>
+      </online>
+    </distribution>
+    <coverage scope="document">
+      <geographicCoverage id="ICMDXX" scope="document">
+        <geographicDescription>Cape Mendocino: ICMDXX: MEN: Temperature data are collected at intertidal survey sites ranging from Alaska to Southern California by MARINe/PISCO.  For more information see http://pacificrockyintertidal.org. Altitude is height above Mean Lower Low Water (MLLW). This is a site temperature logger in the intertidal mid zone.</geographicDescription>
+        <boundingCoordinates>
+          <westBoundingCoordinate>-124.36317</westBoundingCoordinate>
+          <eastBoundingCoordinate>-124.36317</eastBoundingCoordinate>
+          <northBoundingCoordinate>40.341</northBoundingCoordinate>
+          <southBoundingCoordinate>40.341</southBoundingCoordinate>
+          <boundingAltitudes>
+            <altitudeMinimum>0</altitudeMinimum>
+            <altitudeMaximum>0</altitudeMaximum>
+            <altitudeUnits>meter</altitudeUnits>
+          </boundingAltitudes>
+        </boundingCoordinates>
+      </geographicCoverage>
+      <temporalCoverage scope="document">
+        <rangeOfDates>
+          <beginDate>
+            <calendarDate>2017-01-01</calendarDate>
+            <time>00:00:00.00Z</time>
+          </beginDate>
+          <endDate>
+            <calendarDate>2017-12-31</calendarDate>
+            <time>23:45:00.00Z</time>
+          </endDate>
+        </rangeOfDates>
+      </temporalCoverage>
+    </coverage>
+    <purpose>
+      <para>These data were collected by PISCO to understand the physical processes of the inner continental shelf and their potential effects on marine ecology.</para>
+    </purpose>
+    <contact scope="document">
+      <positionName>Research Associate</positionName>
+      <organizationName>MARINe/PISCO Research Group at UC Santa Cruz</organizationName>
+      <electronicMailAddress>Melissa Miner: cmminer@ucsc.edu; Rani Gaddam: gaddam@ucsc.edu</electronicMailAddress>
+      <onlineUrl>https://pacificrockyintertidal.org</onlineUrl>
+    </contact>
+    <methods>
+      <methodStep>
+        <description>
+          <para>Methods for intertidal temperature collection and quality-control are available online, see the protocol citation (it is a Portable Document File and requires a PDF viewer to open).</para>
+        </description>
+        <protocol scope="document">
+          <title>MARINe/PISCO UCSC Intertidal Temperature Logger Protocols</title>
+          <creator scope="document">
+            <organizationName>PISCO</organizationName>
+          </creator>
+          <distribution scope="document">
+            <online>
+              <url function="download">https://cn.dataone.org/cn/v2/resolve/doi:10.6085/AA/PISCO_UCSC_Intertidal_Temperature_Logger_Protocols.40.2</url>
+            </online>
+          </distribution>
+        </protocol>
+        <instrumentation>Onset Tidbit V2 Temp Data Logger (Onset Computer Corp. UTBI-001)</instrumentation>
+      </methodStep>
+      <sampling>
+        <studyExtent>
+          <coverage scope="document">
+            <geographicCoverage scope="document">
+              <geographicDescription>In this sampling section, the altitudeMaximum tag refers to the altitude of Mean Sea Level (MSL), and the altitudeMinimum tag refers to the nominal altitude of the sea floor.  In other words, the altitudeMinimum represents the overall water depth, expressed as a negative altitude.</geographicDescription>
+              <boundingCoordinates>
+                <westBoundingCoordinate>-124.36317</westBoundingCoordinate>
+                <eastBoundingCoordinate>-124.36317</eastBoundingCoordinate>
+                <northBoundingCoordinate>40.341</northBoundingCoordinate>
+                <southBoundingCoordinate>40.341</southBoundingCoordinate>
+                <boundingAltitudes>
+                  <altitudeMinimum>-0</altitudeMinimum>
+                  <altitudeMaximum>000</altitudeMaximum>
+                  <altitudeUnits>meter</altitudeUnits>
+                </boundingAltitudes>
+              </boundingCoordinates>
+            </geographicCoverage>
+          </coverage>
+        </studyExtent>
+        <samplingDescription>
+          <para>Methods for intertidal temperature collection and quality-control are available online, see the protocol citation.</para>
+        </samplingDescription>
+      </sampling>
+    </methods>
+    <project scope="document">
+      <title>Partnership for Interdisciplinary Studies of Coastal Oceans (PISCO)</title>
+      <personnel scope="document">
+        <organizationName>PISCO</organizationName>
+        <role>Consortium</role>
+      </personnel>
+      <abstract>
+        <para>PISCO is a large-scale marine research program that focuses on understanding the near-shore ecosystems of the U.S. West Coast. An interdisciplinary collaboration of scientists from four universities, PISCO integrates long-term monitoring of ecological and oceanographic processes at dozens of coastal sites with experimental work in the lab and field. We explore how individual organisms, populations, and ecological communities vary over space and time.  Findings are applied to issues of ocean conservation and management, and are shared through our public outreach and student training programs.</para>
+      </abstract>
+      <funding>
+        <para>PISCO is funded by the David and Lucile Packard Foundation and the Gordon and Betty Moore Foundation.</para>
+      </funding>
+    </project>
+    <access
+      authSystem="ldap://ldap.ecoinformatics.org:389/dc=ecoinformatics,dc=org"
+      order="denyFirst" scope="document">
+      <allow>
+        <principal>cn=data-managers,o=PISCOGROUPS,dc=ecoinformatics,dc=org</principal>
+        <permission>all</permission>
+      </allow>
+      <allow>
+        <principal>public</principal>
+        <permission>read</permission>
+      </allow>
+      <allow>
+        <principal>cn=pisco-intertidal-write,o=PISCOGROUPS,dc=ecoinformatics,dc=org</principal>
+        <permission>all</permission>
+      </allow>
+    </access>
+    <dataTable scope="document">
+      <entityName>ICMDXX_XXXITV2XMSR01_20170101.40.1.txt</entityName>
+      <physical scope="document">
+        <objectName>ICMDXX_XXXITV2XMSR01_20170101.40.1</objectName>
+        <size unit="bytes">1736119</size>
+        <characterEncoding>ASCII</characterEncoding>
+        <dataFormat>
+          <textFormat>
+            <numHeaderLines>1</numHeaderLines>
+            <recordDelimiter>#x0A</recordDelimiter>
+            <attributeOrientation>column</attributeOrientation>
+            <simpleDelimited>
+              <fieldDelimiter>#x20</fieldDelimiter>
+            </simpleDelimited>
+          </textFormat>
+        </dataFormat>
+        <distribution id="ICMDXX_XXXITV2XMSR01_20170101.40" scope="document">
+          <online>
+            <url function="download">https://cn.dataone.org/cn/v2/resolve/doi:10.6085/AA/ICMDXX_XXXITV2XMSR01_20170101.40.1</url>
+          </online>
+        </distribution>
+      </physical>
+      <attributeList>
+        <attribute scope="document">
+          <attributeName>date</attributeName>
+          <attributeDefinition>calendar date of each temperature measurement record</attributeDefinition>
+          <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">date</storageType>
+          <measurementScale>
+            <datetime>
+              <formatString>YYYY-MM-DD</formatString>
+              <dateTimePrecision>1 day</dateTimePrecision>
+              <dateTimeDomain/>
+            </datetime>
+          </measurementScale>
+        </attribute>
+        <attribute scope="document">
+          <attributeName>time</attributeName>
+          <attributeDefinition>Greenwich Mean Time of each temperature measurement record</attributeDefinition>
+          <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">time</storageType>
+          <measurementScale>
+            <datetime>
+              <formatString>hh:mm:ss.ssZ</formatString>
+              <dateTimePrecision>1 second</dateTimePrecision>
+              <dateTimeDomain/>
+            </datetime>
+          </measurementScale>
+          <accuracy>
+            <attributeAccuracyReport>1 minute/month from Onset Manuals</attributeAccuracyReport>
+          </accuracy>
+        </attribute>
+        <attribute scope="document">
+          <attributeName>yearday</attributeName>
+          <attributeDefinition>Time of each temperature measurement record, expressed as decimal days since 12 a.m. Jan. 1 of the year measurement was made.  For example, 12 noon GMT on Jan. 2 is represented by yearday 1.5, NOT yearday 2.5.</attributeDefinition>
+          <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>nominalDay</standardUnit>
+              </unit>
+              <precision>0.0000116</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+          <accuracy>
+            <attributeAccuracyReport>1 minute/month from Onset Manuals</attributeAccuracyReport>
+          </accuracy>
+        </attribute>
+        <attribute scope="document">
+          <attributeName>temp_c</attributeName>
+          <attributeDefinition>seawater temperature</attributeDefinition>
+          <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>celsius</standardUnit>
+              </unit>
+              <precision>0.02</precision>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+          <missingValueCode>
+            <code>9999.00</code>
+            <codeExplanation>missing data</codeExplanation>
+          </missingValueCode>
+          <accuracy>
+            <attributeAccuracyReport>0.2 degrees Celsius from Manual</attributeAccuracyReport>
+          </accuracy>
+        </attribute>
+        <attribute scope="document">
+          <attributeName>flag</attributeName>
+          <attributeDefinition>data flag used to qualify data as bad, questionable, etc.</attributeDefinition>
+          <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">string</storageType>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>Data for each column of the data file are flagged with a single alpha-numeric code such that the first digit holds the first data column flag, the second digit holds the second data column flag, etc.  Possible flags are 0-9, A-Z, a-z; however flag definitions are currently as follows: 0 - No known bad data; 1 - Known bad data: instrument malfunction/failure, loss of memory, loss of power, bio-fouling, electronic malfunction; 2 - Suspicious data (looks bad, but no known cause); 9 - Missing data (data column has a missing value code as defined in the metadata) [0-9A-Za-z]</definition>
+                  <pattern>[0-9A-Za-z][0-9A-Za-z][0-9A-Za-z][0-9A-Za-z]</pattern>
+                  <source>PISCO/NMS Physical Oceanography Team accepted flagging conventions</source>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+        </attribute>
+      </attributeList>
+    </dataTable>
+  </dataset>
+  <additionalMetadata>
+    <describes>ICMDXX_XXXITV2XMSR01_20170101.40</describes>
+    <access
+      authSystem="ldap://ldap.ecoinformatics.org:389/dc=ecoinformatics,dc=org" order="denyFirst">
+      <allow>
+        <principal>public</principal>
+        <permission>read</permission>
+      </allow>
+      <allow>
+        <principal>cn=data-managers,o=PISCOGROUPS,dc=ecoinformatics,dc=org</principal>
+        <permission>all</permission>
+      </allow>
+      <allow>
+        <principal>cn=pisco-intertidal-write,o=PISCOGROUPS,dc=ecoinformatics,dc=org</principal>
+        <permission>all</permission>
+      </allow>
+    </access>
+  </additionalMetadata>
+</eml:eml>

--- a/d1lod/tests/data/metadata/eml/eml-210.xml
+++ b/d1lod/tests/data/metadata/eml/eml-210.xml
@@ -1,0 +1,924 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eml:eml packageId="knb-lter-arc.10531.6"
+  system="https://pasta.lternet.edu"
+  xmlns:eml="eml://ecoinformatics.org/eml-2.1.0"
+  xmlns:cit="eml://ecoinformatics.org/literature-2.1.0"
+  xmlns:doc="eml://ecoinformatics.org/documentation-2.1.0"
+  xmlns:ds="eml://ecoinformatics.org/dataset-2.1.0"
+  xmlns:prot="eml://ecoinformatics.org/protocol-2.1.0"
+  xmlns:res="eml://ecoinformatics.org/resource-2.1.0"
+  xmlns:stmml="http://www.xml-cml.org/schema/stmml"
+  xmlns:sw="eml://ecoinformatics.org/software-2.1.0"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.0 http://nis.lternet.edu/schemas/EML/eml-2.1.0/eml.xsd">
+  <access authSystem="https://pasta.lternet.edu/authentication"
+    order="allowFirst" scope="document" system="https://pasta.lternet.edu">
+    <allow>
+      <principal>uid=ARC,o=lter,dc=ecoinformatics,dc=org</principal>
+      <permission>all</permission>
+    </allow>
+    <allow>
+      <principal>public</principal>
+      <permission>read</permission>
+    </allow>
+  </access>
+  <dataset id="dataset01">
+    <alternateIdentifier>2002-2013_Kling_AON_Imnavait_Chemistry.06</alternateIdentifier>
+    <title>Biogeochemistry data set for Imnavait Creek Weir on the North Slope of Alaska.</title>
+    <creator id="pers-1">
+      <organizationName>Arctic Observing Network (AON)</organizationName>
+      <individualName>
+        <givenName>George</givenName>
+        <surName>Kling</surName>
+      </individualName>
+      <address>
+        <deliveryPoint>University of Michigan</deliveryPoint>
+        <deliveryPoint>Department of Ecology and Evolutionary Biology</deliveryPoint>
+        <deliveryPoint>830 North University</deliveryPoint>
+        <city>Ann Arbor</city>
+        <administrativeArea>MI</administrativeArea>
+        <postalCode>48109-1048</postalCode>
+        <country>United States of America</country>
+      </address>
+    </creator>
+    <metadataProvider>
+      <organizationName>Arctic Observing Network (AON)</organizationName>
+      <address>
+        <deliveryPoint>The Ecosystems Center</deliveryPoint>
+        <deliveryPoint>Marine Biological Lab</deliveryPoint>
+        <deliveryPoint>7 MBL St</deliveryPoint>
+        <city>Woods Hole</city>
+        <administrativeArea>MA</administrativeArea>
+        <postalCode>02543</postalCode>
+        <country>USA</country>
+      </address>
+      <phone phonetype="voice">(508) 289 7496</phone>
+      <electronicMailAddress>arc_im@mbl.edu</electronicMailAddress>
+      <onlineUrl>http://arc-lter.ecosystems.mbl.edu/AON/</onlineUrl>
+    </metadataProvider>
+    <pubDate>2014</pubDate>
+    <abstract>
+      <para>Data file describing the biogeochemistry of samples collected at Imnavait Creek ,North Slope of Alaska. Sample site descriptors include a unique assigned number (sortchem), site, date, time, depth, distance (downstream), elevation, and category. Physical measures collected in the field include temperature, conductivity, pH. Chemical analysis for the sample include alkalinity; dissolved organic carbon (DOC); inorganic and total dissolved nutrients (NH4, PO4, NO3, TDN, TDP); particulate carbon, nitrogen, and phosphorus (PC, PN, and PP); cations (Ca, Mg, Na, K); anions (SO4 and Cl); silica and oxygen.</para>
+    </abstract>
+    <keywordSet>
+      <keyword>carbon</keyword>
+      <keyword>nitrogen</keyword>
+      <keyword>phosphorus</keyword>
+      <keyword>ammonium</keyword>
+      <keyword>total dissolved nitrogen</keyword>
+      <keyword>alkalinity</keyword>
+      <keyword>dissolved organic carbon</keyword>
+      <keyword>carbon dioxide</keyword>
+      <keyword>methane</keyword>
+      <keyword>pH</keyword>
+      <keyword>temperature</keyword>
+      <keyword>conductivity</keyword>
+      <keyword>particulates</keyword>
+      <keyword>particulate organic carbon</keyword>
+    </keywordSet>
+    <dataTable id="my.data.table">
+      <entityName>Example DataTable</entityName>
+      <entityDescription>Example entityDescription</entityDescription>
+      <annotation>
+        <propertyURI label="is about">http://purl.obolibrary.org/obo/IAO_0000136</propertyURI>
+        <valueURI label="Mammalia">http://purl.obolibrary.org/obo/NCBITaxon_40674</valueURI>
+      </annotation>
+      <attributeList>
+        <attribute id="my.attribute">
+          <attributeName>ExampleAttribute</attributeName>
+          <attributeDefinition>ExampleAttribute</attributeDefinition>
+          <measurementScale>
+            <dateTime>
+              <formatString>YYYY</formatString>
+            </dateTime>
+          </measurementScale>
+          <annotation>
+            <propertyURI label="contains measurements of type">http://ecoinformatics.org/oboe/oboe.1.2/oboe-core.owl#containsMeasurementsOfType</propertyURI>
+            <valueURI label="Plant Cover Percentage">http://purl.dataone.org/odo/ECSO_00001197</valueURI>
+          </annotation>
+        </attribute>
+      </attributeList>
+    </dataTable>
+    <intellectualRights>
+      <para>This work is licensed under the Creative Commons Attribution 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/.</para>
+      <para>The re-use of scientific data has the potential to greatly increase communication, collaboration and synthesis within and among disciplines, and thus is fostered, supported and encouraged. Permission to use this dataset is granted to the Data User free of charge subject to the following terms:</para>
+      <para>
+        <itemizedlist>
+          <listitem>
+            <para>Citation. It is considered a matter of professional ethics to acknowledge the work of other scientists. Thus, the Data User should properly cite the Data Set in any publications or in the metadata of any derived data products that were produced using the Data Set.</para>
+          </listitem>
+          <listitem>
+            <para>Acknowledgement. The Data User should acknowledge any institutional support or specific funding awards referenced in the metadata accompanying this dataset in any publications where the Data Set contributed significantly to its content. Acknowledgements should identify the supporting party, the party that received the support, and any identifying information such as grant numbers. For example: Data sets were provided by the Arctic LTER. This material is based upon work supported by the National Science Foundation under Grants #ARC-1107593, 1107707, 0632139 and #DEB-1026843.</para>
+          </listitem>
+          <listitem>
+            <para>Notification. The Data User will notify the Data Set Contact when any derivative work or publication based on or derived from the Data Set is distributed. The Data User will provide the data contact with two reprints of any publications resulting from use of the Data Set and will provide copies, or online access to, any derived digital products. Notification will include an explanation of how the Data Set was used to produce the derived work.</para>
+          </listitem>
+          <listitem>
+            <para>Collaboration. The Data Set has been released in the spirit of open scientific collaboration. Data Users are thus strongly encouraged to consider consultation, collaboration and/or co-authorship with the Data Set Creator.</para>
+          </listitem>
+          <listitem>
+            <para>Disclaimer. While substantial efforts are made to ensure the accuracy of data and documentation contained in this Data Set, complete accuracy of data and metadata cannot be guaranteed. All data and metadata are made available "as is". The Data User holds all parties involved in the production or distribution of the Data Set harmless for damages resulting from its use or interpretation.</para>
+          </listitem>
+        </itemizedlist>
+      </para>
+    </intellectualRights>
+    <distribution>
+      <online>
+        <url>http://arc-lter.ecosystems.mbl.edu/2002-2013KlingAONImnavaitChemistry</url>
+      </online>
+    </distribution>
+    <coverage>
+      <geographicCoverage id="GEO-1">
+        <geographicDescription>Arctic LTER Site number 1140</geographicDescription>
+        <boundingCoordinates>
+          <westBoundingCoordinate>-149.317799</westBoundingCoordinate>
+          <eastBoundingCoordinate>-149.317799</eastBoundingCoordinate>
+          <northBoundingCoordinate>68.617081</northBoundingCoordinate>
+          <southBoundingCoordinate>68.617081</southBoundingCoordinate>
+        </boundingCoordinates>
+      </geographicCoverage>
+      <temporalCoverage>
+        <rangeOfDates>
+          <beginDate>
+            <calendarDate>2002-06-05</calendarDate>
+          </beginDate>
+          <endDate>
+            <calendarDate>2013-08-15</calendarDate>
+          </endDate>
+        </rangeOfDates>
+      </temporalCoverage>
+    </coverage>
+    <maintenance>
+      <description>
+        <para>21 October 2014: Generated this file (version .01) -jad/gwk</para>
+        <para>Version 2: Corrected publish date Jim l Oct2014</para>
+        <para>Version 4: Changed Distrubution URL since the LTER network DAS system is being discontinued. JimL 9Apr2015</para>
+        <para>Version 5: Updated data use policy. BK.</para>
+        <para>Version 6: Added grant numbers to eml. JL</para>
+      </description>
+    </maintenance>
+    <contact id="im" system="knb">
+      <positionName>Data Manager</positionName>
+      <address>
+        <deliveryPoint>The Ecosystems Center</deliveryPoint>
+        <deliveryPoint>Marine Biological Lab</deliveryPoint>
+        <deliveryPoint>7 MBL St</deliveryPoint>
+        <city>Woods Hole</city>
+        <administrativeArea>MA</administrativeArea>
+        <postalCode>02543</postalCode>
+        <country>USA</country>
+      </address>
+      <phone phonetype="voice">(508) 289 7496</phone>
+      <electronicMailAddress>arc_im@mbl.edu</electronicMailAddress>
+      <onlineUrl>http://arc-lter.ecosystems.mbl.edu/</onlineUrl>
+    </contact>
+    <publisher>
+      <organizationName>ARC LTER</organizationName>
+      <address>
+        <deliveryPoint>The Ecosystems Center</deliveryPoint>
+        <deliveryPoint>Marine Biological Lab</deliveryPoint>
+        <deliveryPoint>7 MBL St</deliveryPoint>
+        <city>Woods Hole</city>
+        <administrativeArea>MA</administrativeArea>
+        <postalCode>02543</postalCode>
+        <country>USA</country>
+      </address>
+      <phone phonetype="voice">(508) 289 7496</phone>
+      <electronicMailAddress>arc_im@mbl.edu</electronicMailAddress>
+      <onlineUrl>http://arc-lter.ecosystems.mbl.edu//</onlineUrl>
+    </publisher>
+    <methods>
+      <methodStep>
+        <description>
+          <para>
+            <literalLayout>
+For water sampling protocols see the Arctic LTER Land-Water group protocol book accessible from the Land-Water mainpage on the Arctic LTER web page or at http://www-personal.umich.edu/~gwk and clicking on the protocol link at the bottom of the page.  Specific methodologies are described in the protocol book listed above and a general description is provided below.
+
+General analyses:  In general water samples from soils, streams, and lakes are filtered in the field and kept cold and dark or preserved until analysis.  Dissolved inorganic nutrients (NH4 and PO4) were analyzed by wet chemistry techniques at Toolik Field Station usually within 24 hours of sampling.  Dissolved gases CO2 and CH4 were determined using a syringe equilibration method and analyzed at Toolik Field Station on a gas chromatograph.  DOC, TDN, TDP, particulate C, N, and P, and dissolved ions were brought back to the University of Michigan for analysis.  DOC is analyzed on a Shimadzu TOC-5000 or a TOC-V.  Particulate Carbon and Nitrogen on a Perkin Elmer CHN 2400, TDN is analyzed on a Shimadzu TOC-5000 or TOC-V or using a persulfate digestion.  TDP and NO3 are analyzed on an OI Alpkem autoanalyzer, ions on a Dionex ion chromatograph, and cations on an inductively coupled plasma optical emission spectrometer (ICP-OES Perkin Elmer Optima 4300 or 8000).  Alkalinity samples were run on a Radiometer autotitrator.
+
+For all analyses, sample values that were less than zero were assigned a value of zero.  See specific protocols for limits of detection.  Missing values (not sampled or analyzed) are represented by a period " . " in the dataset.
+
+</literalLayout>
+          </para>
+        </description>
+        <protocol>
+          <title>Field and Lab Methods &amp; Protocols</title>
+          <creator>
+            <references>pers-1</references>
+          </creator>
+          <distribution>
+            <online>
+              <url>http://arc-lter.ecosystems.mbl.edu/landwater/lw_protocols</url>
+            </online>
+          </distribution>
+          <proceduralStep>
+            <description>
+              <para>http://arc-lter.ecosystems.edu/landwater/lw_protocols</para>
+            </description>
+          </proceduralStep>
+        </protocol>
+      </methodStep>
+    </methods>
+    <project>
+      <title>Collaborative Research on Carbon, Water, and Energy Balance of the Arctic Landscape at Flagship Observatories in Alaska and Siberia.</title>
+      <personnel>
+        <individualName>
+          <givenName>George</givenName>
+          <surName>Kilng</surName>
+        </individualName>
+        <address>
+          <deliveryPoint>University of Michigan Ann Arbor</deliveryPoint>
+          <deliveryPoint>3003 South State St. Room 1062</deliveryPoint>
+          <city>Ann Arbor</city>
+          <administrativeArea>MI</administrativeArea>
+          <postalCode>48109</postalCode>
+          <country>USA</country>
+        </address>
+        <role>originator</role>
+      </personnel>
+      <abstract>
+        <para>The arctic landscape interacts with the global and regional climate by exchanging carbon dioxide, methane, water, and energy with the atmosphere. Understanding how these exchanges are regulated and how they change is a key goal of the US Study of Environmental Arctic Change and the NSF Arctic Observatory Network. The first goal of this work is year round monitoring of carbon, water, and energy balance at two arctic sites, Imnavait Creek in Alaska and Cherskii in Siberia. The work will be a collaboration among researchers from the Marine Biological Laboratory, the University of Alaska Fairbanks, Northeast Science Station, Russia, and the University of Michigan. The second goal is the development of these two sites as ?Flagship? observatories for research on arctic lands and freshwaters. The main task here is to integrate the new carbon, water, and energy balance data with the already large, diverse, and growing data bases from other research done at these sites. A third aim is to promote PanArctic comparisons and development of PanArctic data bases.</para>
+        <para>Broader impacts include contributions to education, including underrepresented groups, through participation in the Logan Science Journalism program, the Arctic Long-Term Ecological Research Schoolyard program, and outreach to Native Alaskan communities. Research and education infrastructure will be enhanced by making the data bases available online. Benefits to society include improved understanding of the impacts of climate change, especially in Alaska where the local residents are closely tied to the land through traditional, subsistence lifestyles.</para>
+      </abstract>
+      <funding>
+        <para>1107593</para>
+        <para>1107707</para>
+        <para>0632139</para>
+        <para>1026843</para>
+      </funding>
+      <studyAreaDescription>
+        <coverage>
+          <geographicCoverage>
+            <geographicDescription>The AON research site (68°N and 149°W) is in the foothills region of the North Slope of Alaska. This area is typical of the northern foothills of the Brooks Range, with continuous permafrost, no trees, a complete snow cover for 7 to 9 months, winter ice cover on lakes, streams, and ocean, and cessation of river flow during the winter. Tussock tundra vegetation of sedges and grasses mixed with dwarf birch and low willows form the dominant vegetation type with areas of drier heath tundra on ridge tops and other well-drained sites as well as areas of river-bottom willow communities.</geographicDescription>
+            <boundingCoordinates>
+              <westBoundingCoordinate>-149.75</westBoundingCoordinate>
+              <eastBoundingCoordinate>-149.0433</eastBoundingCoordinate>
+              <northBoundingCoordinate>68.8</northBoundingCoordinate>
+              <southBoundingCoordinate>68.5</southBoundingCoordinate>
+              <boundingAltitudes>
+                <altitudeMinimum>610</altitudeMinimum>
+                <altitudeMaximum>1360</altitudeMaximum>
+                <altitudeUnits>meter</altitudeUnits>
+              </boundingAltitudes>
+            </boundingCoordinates>
+          </geographicCoverage>
+        </coverage>
+      </studyAreaDescription>
+    </project>
+    <dataTable>
+      <entityName>2002-2013_Kling_AON_Imnavait_Chemistry.csv</entityName>
+      <entityDescription>Biogeochemistry data set for Imnavait Creek Weir on the North Slope of Alaska.</entityDescription>
+      <physical>
+        <objectName>2002-2013_Kling_AON_Imnavait_Chemistry.csv</objectName>
+        <dataFormat>
+          <textFormat>
+            <numHeaderLines>1</numHeaderLines>
+            <recordDelimiter>\r\n</recordDelimiter>
+            <attributeOrientation>column</attributeOrientation>
+            <simpleDelimited>
+              <fieldDelimiter>,</fieldDelimiter>
+              <quoteCharacter>"</quoteCharacter>
+            </simpleDelimited>
+          </textFormat>
+        </dataFormat>
+        <distribution>
+          <online>
+            <url>https://pasta.lternet.edu/package/data/eml/knb-lter-arc/10531/6/4a8d9b5e6280c09eb66c2a8d7c0d606e</url>
+          </online>
+        </distribution>
+      </physical>
+      <attributeList>
+        <attribute id=" att0.1">
+          <attributeName>SortChem</attributeName>
+          <attributeLabel>SortChem</attributeLabel>
+          <attributeDefinition>A unique number assigned to each sample collected at a specific site at a specific date and time. The year that the sample was collected is followed by a dash and then a sequential number. For example, if 600 samples were collected in 2002, then the first sample collected is 2002-0001 and the last sample is 2002-0600.</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>A unique number assigned to each sample collected at a specific site at a specific date and time. The year that the sample was collected is followed by a dash and then a sequential number. For example, if 600 samples were collected in 2002, then the first sample collected is 2002-0001 and the last sample is 2002-0600.</definition>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.2">
+          <attributeName>Site</attributeName>
+          <attributeLabel>Site</attributeLabel>
+          <attributeDefinition>Site Name. If a soil site, the site is described in the name by general location then specific feature (e.g., watertrack) then specific sampling point (1,2,3,...). Lake and stream sites use common names (e.g., Toolik) or LTER number codes. Exceptions in naming procedure are provided in the Code Information and in the AK-LTER_Site_Info.xls file.</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>Site Name. If a soil site, the site is described in the name by general location then specific feature (e.g., watertrack) then specific sampling point (1,2,3,...). Lake and stream sites use common names (e.g., Toolik) or LTER number codes. Exceptions in naming procedure are provided in the Code Information and in the AK-LTER_Site_Info.xls file.</definition>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.3">
+          <attributeName>Date</attributeName>
+          <attributeLabel>Date</attributeLabel>
+          <attributeDefinition>Sampling Date</attributeDefinition>
+          <measurementScale>
+            <dateTime>
+              <formatString>dd-mon-yyyy</formatString>
+            </dateTime>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.4">
+          <attributeName>Time_hr_dst</attributeName>
+          <attributeLabel>Time_hr_dst</attributeLabel>
+          <attributeDefinition>Sampling Time in Alaska Daylight Savings Time (1 hour ahead of Alaska Standard Time: if 13:00 DST than 12:00 AST)</attributeDefinition>
+          <measurementScale>
+            <dateTime>
+              <formatString>hh24:mi</formatString>
+            </dateTime>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.5">
+          <attributeName>Depth_m</attributeName>
+          <attributeLabel>Depth_m</attributeLabel>
+          <attributeDefinition>Depth from surface of lake, stream, or soil, or a description of location such as "meta" for metalimnion.</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>Depth from surface of lake, stream, or soil, or a description of location such as "meta" for metalimnion.</definition>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.6">
+          <attributeName>Distance_km</attributeName>
+          <attributeLabel>Distance_km</attributeLabel>
+          <attributeDefinition>Distance along a stream where negative values are upstream of a designated starting point and positive values are downstream of the designated starting point. For soil sites, the distance is the perpendicular distance from the river or lake shore. Can include a text description.</attributeDefinition>
+          <measurementScale>
+            <nominal>
+              <nonNumericDomain>
+                <textDomain>
+                  <definition>Distance along a stream where negative values are upstream of a designated starting point and positive values are downstream of the designated starting point. For soil sites, the distance is the perpendicular distance from the river or lake shore. Can include a text description.</definition>
+                </textDomain>
+              </nonNumericDomain>
+            </nominal>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.7">
+          <attributeName>Elevation_m</attributeName>
+          <attributeLabel>Elevation_m</attributeLabel>
+          <attributeDefinition>Elevation above sea level</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <standardUnit>meter</standardUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.8">
+          <attributeName>Temp_C</attributeName>
+          <attributeLabel>Temp_C</attributeLabel>
+          <attributeDefinition>Sample water temperature, deg C</attributeDefinition>
+          <measurementScale>
+            <interval>
+              <unit>
+                <standardUnit>celsius</standardUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </interval>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.9">
+          <attributeName>Cond_uS</attributeName>
+          <attributeLabel>Cond_uS</attributeLabel>
+          <attributeDefinition>Electrical conductivity of the water sample</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>microsiemenPerCentimeter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.10">
+          <attributeName>pH</attributeName>
+          <attributeLabel>pH</attributeLabel>
+          <attributeDefinition>pH (opposite of the log of the molar hydrogen ion concentration)</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <standardUnit>number</standardUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.11">
+          <attributeName>Alk_ueqL</attributeName>
+          <attributeLabel>Alk_ueqL</attributeLabel>
+          <attributeDefinition>Total alkalinity (carbonate and non-carbonate alkalinity)</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>microequivalentPerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.12">
+          <attributeName>PCO2_uatm</attributeName>
+          <attributeLabel>PCO2_uatm</attributeLabel>
+          <attributeDefinition>Partial pressure of carbon dioxide</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>microatmosphere</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.13">
+          <attributeName>PCH4_uatm</attributeName>
+          <attributeLabel>PCH4_uatm</attributeLabel>
+          <attributeDefinition>Partial pressure of methane gas</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>microatmosphere</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.14">
+          <attributeName>CO2_uM</attributeName>
+          <attributeLabel>CO2_uM</attributeLabel>
+          <attributeDefinition>Dissolved carbon dioxide gas concentration</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.15">
+          <attributeName>CH4_uM</attributeName>
+          <attributeLabel>CH4_uM</attributeLabel>
+          <attributeDefinition>Dissolved methane gas concentration</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.16">
+          <attributeName>DOC_uM</attributeName>
+          <attributeLabel>DOC_uM</attributeLabel>
+          <attributeDefinition>Dissolved organic carbon</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.17">
+          <attributeName>NH4_OPA_uM</attributeName>
+          <attributeLabel>NH4_OPA_uM</attributeLabel>
+          <attributeDefinition>Ammonium by the OPA method</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.18">
+          <attributeName>PO4_uM</attributeName>
+          <attributeLabel>PO4_uM</attributeLabel>
+          <attributeDefinition>Phosphate (Soluble Reactive Phosphorus)</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.19">
+          <attributeName>NO3_uM</attributeName>
+          <attributeLabel>NO3_uM</attributeLabel>
+          <attributeDefinition>Nitrate</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.20">
+          <attributeName>TDN_uM</attributeName>
+          <attributeLabel>TDN_uM</attributeLabel>
+          <attributeDefinition>Total dissolved nitrogen</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.21">
+          <attributeName>TDP_uM</attributeName>
+          <attributeLabel>TDP_uM</attributeLabel>
+          <attributeDefinition>Total dissolved phosphorus</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.22">
+          <attributeName>PC_ugL</attributeName>
+          <attributeLabel>PC_ugL</attributeLabel>
+          <attributeDefinition>Particulate carbon</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>microgramPerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.23">
+          <attributeName>PN_ugL</attributeName>
+          <attributeLabel>PN_ugL</attributeLabel>
+          <attributeDefinition>Particulate nitrogen</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>microgramPerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.24">
+          <attributeName>PP_uM</attributeName>
+          <attributeLabel>PP_uM</attributeLabel>
+          <attributeDefinition>Particulate phosphorus</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.25">
+          <attributeName>Ca_uM</attributeName>
+          <attributeLabel>Ca_uM</attributeLabel>
+          <attributeDefinition>Calcium</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.26">
+          <attributeName>Mg_uM</attributeName>
+          <attributeLabel>Mg_uM</attributeLabel>
+          <attributeDefinition>Magnesium</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.27">
+          <attributeName>Na_uM</attributeName>
+          <attributeLabel>Na_uM</attributeLabel>
+          <attributeDefinition>Sodium</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.28">
+          <attributeName>K_uM</attributeName>
+          <attributeLabel>K_uM</attributeLabel>
+          <attributeDefinition>Potassium</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.29">
+          <attributeName>Si_uM</attributeName>
+          <attributeLabel>Si_uM</attributeLabel>
+          <attributeDefinition>Silica</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.30">
+          <attributeName>SO4_uM</attributeName>
+          <attributeLabel>SO4_uM</attributeLabel>
+          <attributeDefinition>Sulfate</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+        <attribute id=" att0.31">
+          <attributeName>Cl_uM</attributeName>
+          <attributeLabel>Cl_uM</attributeLabel>
+          <attributeDefinition>Chloride</attributeDefinition>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <customUnit>micromolePerLiter</customUnit>
+              </unit>
+              <numericDomain>
+                <numberType>real</numberType>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+          <missingValueCode>
+            <code>.</code>
+            <codeExplanation>Missing values</codeExplanation>
+          </missingValueCode>
+        </attribute>
+      </attributeList>
+      <numberOfRecords>793</numberOfRecords>
+    </dataTable>
+    <otherEntity>
+      <entityName>2002-2013_Kling_AON_Imnavait_Chemistry.xlsx</entityName>
+      <entityDescription>An excel file that has worksheets with the metadata and data.</entityDescription>
+      <physical scope="document">
+        <objectName>2002-2013_Kling_AON_Imnavait_Chemistry.xlsx</objectName>
+        <dataFormat>
+          <externallyDefinedFormat>
+            <formatName>Microsoft Excel</formatName>
+          </externallyDefinedFormat>
+        </dataFormat>
+        <distribution scope="document">
+          <online>
+            <url>https://pasta.lternet.edu/package/data/eml/knb-lter-arc/10531/6/38943544697d997b83e85a3ab894e776</url>
+          </online>
+        </distribution>
+      </physical>
+      <entityType>Microsoft Excel file</entityType>
+    </otherEntity>
+  </dataset>
+    <annotations>
+    <annotation references="dataset01">
+      <propertyURI label="is about">http://purl.obolibrary.org/obo/IAO_0000136</propertyURI>
+      <valueURI label="grassland biome">http://purl.obolibrary.org/obo/ENVO_01000177</valueURI>
+    </annotation>
+    <annotation references="test.user">
+      <propertyURI label="is a">http://www.w3.org/1999/02/22-rdf-syntax-ns#type</propertyURI>
+      <valueURI label="Person">https://schema.org/Person</valueURI>
+    </annotation>
+  </annotations>
+  <additionalMetadata>
+    <metadata>
+      <unitList>
+        <unit id="microsiemenPerCentimeter" multiplierToSI=""
+          name="microsiemenPerCentimeter" parentSI="" unitType="conductance">
+          <description>conductivity unit</description>
+        </unit>
+        <unit id="microequivalentPerLiter" multiplierToSI=""
+          name="microequivalentPerLiter" parentSI="molePerCubicMeter" unitType="amountOfSubstanceConcentration">
+          <description>concentration of charge (on dissolved ions). A single multiplier to SI is not possible</description>
+        </unit>
+        <unit id="microatmosphere" multiplierToSI="0.101325"
+          name="microatmosphere" parentSI="pascal" unitType="pressure">
+          <description>microatmosphere = .101325 pascals</description>
+        </unit>
+        <unit id="micromolePerLiter" multiplierToSI="0.000001"
+          name="micromolePerLiter" parentSI="molarity" unitType="amountOfSubstanceConcentration">
+          <description>µM = µmoles per liter of solution</description>
+        </unit>
+        <unit id="microgramPerLiter" multiplierToSI=""
+          name="microgramPerLiter" parentSI="" unitType=" volumetricMassDensityRate">
+          <description>micrograms per liter</description>
+        </unit>
+      </unitList>
+    </metadata>
+  </additionalMetadata>
+</eml:eml>

--- a/d1lod/tests/data/metadata/eml/eml-211.xml
+++ b/d1lod/tests/data/metadata/eml/eml-211.xml
@@ -1,0 +1,966 @@
+<eml:eml xmlns:ds="eml://ecoinformatics.org/dataset-2.1.1" xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" xmlns:stmml="http://www.xml-cml.org/schema/schema24" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" packageId="knb-lter-cce.311.1" scope="system" system="https://pasta.edirepository.org" xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 http://nis.lternet.edu/schemas/EML/eml-2.1.1/eml.xsd">
+    <access authSystem="https://pasta.edirepository.org/authentication" order="allowFirst" scope="document" system="https://pasta.edirepository.org">
+        <allow>
+            <principal>uid=CCE,o=EDI,dc=edirepository,dc=org</principal>
+            <permission>all</permission>
+        </allow>
+        <allow>
+            <principal>public</principal>
+            <permission>read</permission>
+        </allow>
+    </access>
+    <dataset scope="document">
+        <alternateIdentifier>311</alternateIdentifier>
+        <alternateIdentifier system="https://doi.org">doi:10.6073/pasta/cce85e7ac6ff272f4637869b0d888827</alternateIdentifier>
+        <title>Gut Fluorescence measurements of mesozooplankton grazing on autotrophic prey. Samples collected in the CCE-LTER region on Process Cruises from 2006 to the present. Summaries for each Lagrangian Cycle.</title>
+        <creator>
+            <organizationName>California Current Ecosystem LTER</organizationName>
+            <address>
+                <deliveryPoint>California Current Ecosystem LTER Program Office Scripps Institution of Oceanography University of California, San Diego 9500 Gilman Dr.</deliveryPoint>
+                <city>La Jolla</city>
+                <administrativeArea>California</administrativeArea>
+                <postalCode>92093-0218</postalCode>
+                <country>USA</country>
+            </address>
+        </creator>
+        <creator>
+            <individualName>
+                <givenName>Mark</givenName>
+                <surName>Ohman</surName>
+            </individualName>
+            <organizationName>SIO</organizationName>
+            <electronicMailAddress>mohman@ucsd.edu</electronicMailAddress>
+        </creator>
+        <metadataProvider>
+            <organizationName>California Current Ecosystem LTER</organizationName>
+            <address>
+                <deliveryPoint>California Current Ecosystem LTER Program Office Scripps Institution of Oceanography University of California, San Diego 9500 Gilman Dr.</deliveryPoint>
+                <city>La Jolla</city>
+                <administrativeArea>California</administrativeArea>
+                <postalCode>92093-0218</postalCode>
+                <country>USA</country>
+            </address>
+        </metadataProvider>
+        <pubDate>2021-10-29</pubDate>
+        <abstract>Mesozooplankton are collected with plankton nets (typically a 71-cm diameter, 202-um mesh Bongo net) and samples flash frozen at sea in liquid N2 for subsequent shore-based measurements of ingested phytoplankton chlorophyll-a. Measurements of mesozooplankton gut fluorescence are done by fluorometric analysis on a Turner Designs fluorometer of gut pigments extracted in 90% acetone. Analyses are done on mesozooplankton size-fractionated into 5 different categories on Nitex mesh (> 0.2 mm, 0.5 mm, 1.0 mm, 2.0 mm, 5.0 mm). The pigment content (as Chl-a and phaeopigments) is then expressed as mass of pigment ingested per m3 of water filtered, or divided by the dry weight biomass of the mesozooplankton in the same sample in order to obtain mass-specific ingestion per m3 of water. Application of published values of the temperature-dependent gut passage time are used to estimate the mesozooplankton grazing rate, as pigments ingested per m3 per unit time, or the corresponding mass-specific rate of ingestion. Samples for gut fluorescence assays have been collected on CCE-LTER Process Cruises since 2006 and these collections are ongoing. </abstract>
+        <keywordSet>
+            <keyword>biogeochemistry</keyword>
+            <keyword>carbon flux</keyword>
+            <keyword>chlorophyll a</keyword>
+            <keyword>grazing</keyword>
+            <keyword>herbivory</keyword>
+            <keywordThesaurus>LTER Controlled Vocabulary</keywordThesaurus>
+        </keywordSet>
+        <keywordSet>
+            <keyword>Mesozooplankton</keyword>
+            <keywordThesaurus>CCE LTER Keywords</keywordThesaurus>
+        </keywordSet>
+        <intellectualRights>
+            <para>This data package is released to the public domain under Creative Commons CC0 1.0 No Rights Reserved (see: https://creativecommons.org/publicdomain/zero/1.0/). It is considered professional etiquette to provide attribution of the original work if this data package is shared in whole or by individual components. A generic citation is provided for this data package on the website https://portal.edirepository.org (herein website” in the summary metadata page. Communication (and collaboration) with the creators of this data package is recommended to prevent duplicate research or publication. This data package (and its components) is made available as is and with no warranty of accuracy or fitness for use. The creators of this data package and the website shall not be liable for any damages resulting from misinterpretation or misuse of the data package or its components. Periodic updates of this data package may be available from the website. Thank you. </para>
+        </intellectualRights>
+        <distribution>
+            <online>
+                <url function="information">https://oceaninformatics.ucsd.edu/datazoo/catalogs/ccelter/datasets/311</url>
+            </online>
+        </distribution>
+        <coverage>
+            <temporalCoverage>
+                <rangeOfDates>
+                    <beginDate>
+                        <calendarDate>2006-05-01</calendarDate>
+                    </beginDate>
+                    <endDate>
+                        <calendarDate>2017-06-30</calendarDate>
+                    </endDate>
+                </rangeOfDates>
+            </temporalCoverage>
+        </coverage>
+        <contact>
+            <positionName>CCE LTER Information Manager</positionName>
+            <organizationName>California Current Ecosystem LTER</organizationName>
+            <electronicMailAddress>ccelter.im@gmail.com</electronicMailAddress>
+        </contact>
+        <publisher>
+            <organizationName>Environmental Data Initiative</organizationName>
+            <electronicMailAddress>info@environmentaldatainitiative.org</electronicMailAddress>
+            <onlineUrl>https://environmentaldatainitiative.org</onlineUrl>
+            <userId directory="https://ror.org">0330j0z60</userId>
+        </publisher>
+        <pubPlace>Environmental Data Initiative</pubPlace>
+        <methods>
+            <methodStep>
+                <description>
+                    <section>
+                        <title>Mesozooplankton sampling by Bongo net</title>
+                        <para>Mesozooplankton are sampled with quantitative plankton nets, usually a 0.71-m diameter Bongo net frame, using the CalCOFI sampling protocol (https://cce.lternet.edu/data/methods-manual/augmented-cruises/calbobl-net-depolyment). However, unlike CalCOFI, we use 202-um Nitex mesh nets and hard cod ends with the same size mesh. A calibrated General Oceanics flow meter is mounted in the mouth of one net. Samples are typically double oblique (from surface to 210 m to surface; depth is based on 300 mwo with a 45° wire angle) or vertical (from surface to 100 m to surface; nominal 0° wire angle). A stainless steel weight (ca. 50 kg) is mounted to the bottom of the bongo frame. Samples from one side of the bongo net are preserved in sodium borate-buffered Formalin (final concentration of 5% Formalin = 1.85% formaldehyde). Samples from the other net are used for gut fluorescence and dry mass biomass determination. The latter samples are anesthetized with soda water immediately upon retrieval to inhibit net feeding and regurgitation. Both nets are carefully washed to ensure quantitative recovery of all sampled material.</para>
+                    </section>
+                </description>
+            </methodStep>
+            <methodStep>
+                <description>
+                    <section>
+                        <title>Size fractionation and flash freezing samples</title>
+                        <para>The anaesthetized zooplankton sample is taken promptly into a shipboad laboratory and split on a Folsom splitter to obtain 3/8 of the sample for gut fluorescence, 3/8 of the sample for dry biomass, and 1/4 of the sample for molecular probes. Samples are kept cool while processing. The gut fluorescence and the biomass aliquots are passed separately through a nested 5-filter series of Nitex sieves resulting in 5 size fractions (0.2-0.5 mm, 0.5-1.0 mm, 1.0-2.0 mm, 2.0-5.0 mm, > 5.0 mm). Each of these samples is concentrated on a 202-um mesh filter, placed in a labelled plastic petri dish, and flash frozen in liquid N2 for analysis ashore. </para>
+                    </section>
+                </description>
+            </methodStep>
+            <methodStep>
+                <description>
+                    <section>
+                        <title>Sorting and fluorometric analysis in the laboratory.</title>
+                        <para>In the laboratory, frozen filters of zooplankton are placed on a dividing block and sliced into fractions for analysis using a clean razor blade. Typically filters are divided as follows: 5 mm - ½ filter ; 2 mm - ¼ filter ; 2 mm - two ¼ filters; 0.5 mm - two 1/8 filters; 0.2 mm - two 1/8 filters. Each fraction to be analyzed is kept on ice for a short time, in the dark, until sorting. Sorting is done under a dissecting microscope with cool white illumination and no room lights, to avoid photodegrading pigments. Detritus and phytoplankton debris are separated from zooplankton using fine needles. The cleaned zooplankton are transfered to a vial containing 10 mL of 90% acetone in an extraction tube and kept on ice, in the dark, until extraction. Extraction is done by immersing a micro-sonication probe into the acetone solution and applying four 5-s bursts at a sonciator setting of 7, while holding the extraction tube in a beaker in ice water. If organisms remain intact, the sample is sonciated with two additional 5-s bursts. Pigments are extracted in a -20 C freezer for one hour in the dark, then inverted twice to mix, placed in a clincial centrifuge, and spun for 10 min at maximum speed. For analysis: Two 4-mL aliquots of supernatant are pipetted into separate cuvettes. Fluorescence is recorded in a calibrated Turner Designs 10AU fluorometer, before and after acidification with 10% HCl. 90% acetone blanks are subtracted from sample readings.</para>
+                    </section>
+                </description>
+            </methodStep>
+            <methodStep>
+                <description>
+                    <section>
+                        <title>Calculation of grazing per unit volume and grazing rate per unit volume.</title>
+                        <para>Fluorometric readings are converted to equivalent concentration of Chl-a and Phaeopigments (phaeophorbide plus phaeophytin) using the standard equations from Strickland and Parsons (1972. A practical handbook of seawater analysis, 2nd ed. Fisheries Research Board of Canada. Bull. 167: 328 p). The amount of pigment analyzed is corrected for filter aliquot fraction, for the fraction of the sample split at sea, and for the volume of water filtered by the plankton net, to obtain the mass of phytoplankton pigment ingested by zooplankton per m3 of seawater filtered. Data can also be expressed as the mass of pigment ingested by mesozooplankton per m2 of sea surface by multiplying by the maximum depth of the tow. Concentrations of pigment ingested can be converted a grazing rate (i.e., mass of pigment ingested per m3 or m2 per unit time) by correcting for the temperature-dependent gut turnover rate of pigments. Gut turnover rates have been determined by Dam and Peterson (1988) as updated in Bamstedt et al. (2000. p. 297-399. In R. P. Harriset al [eds.], ICES Zooplankton Methodology Manual. Academic.) For this purpose, zooplankton are assumed to feed primarily at the temperature corresponding to the depth of the chlorophyll-a maximum layer.</para>
+                    </section>
+                </description>
+            </methodStep>
+        </methods>
+        <dataTable id="311.table_321">
+            <entityName>process_cruise_zooplankton_gut_fluorescence</entityName>
+            <entityDescription>Gut Fluorescence measurements of mesozooplankton grazing on autotrophic prey. Samples collected in the CCE-LTER region on Process Cruises from 2006 to the present. Summaries for each Lagrangian Cycle.</entityDescription>
+            <physical>
+                <objectName>table_321.csv</objectName>
+                <characterEncoding>ASCII</characterEncoding>
+                <dataFormat>
+                    <textFormat>
+                        <numHeaderLines>1</numHeaderLines>
+                        <numFooterLines>0</numFooterLines>
+                        <recordDelimiter>\n</recordDelimiter>
+                        <attributeOrientation>column</attributeOrientation>
+                        <simpleDelimited>
+                            <fieldDelimiter>,</fieldDelimiter>
+                            <quoteCharacter>"</quoteCharacter>
+                            <literalCharacter>\</literalCharacter>
+                        </simpleDelimited>
+                    </textFormat>
+                </dataFormat>
+                <distribution>
+                    <online>
+                        <url function="download">https://pasta.lternet.edu/package/data/eml/knb-lter-cce/311/1/f022c2dbfd56c285fd68b9df58ec1f02</url>
+                    </online>
+                </distribution>
+            </physical>
+            <attributeList>
+                <attribute id="311.table_321.studyName">
+                    <attributeName>studyName</attributeName>
+                    <attributeDefinition>Sampling expedition from which data were collected, generated, etc.</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">string</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sampling expedition from which data were collected, generated, etc.</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                </attribute>
+                <attribute id="311.table_321.col_6409">
+                    <attributeName>cruise</attributeName>
+                    <attributeDefinition>Cruise designations are "P" for Process Cruise, followed by a 2-digit year and 2-digit month. For example, P0605 is the Process Cruise that took place primarily in May 2006.</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">string</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Cruise designations are "P" for Process Cruise, followed by a 2-digit year and 2-digit month. For example, P0605 is the Process Cruise that took place primarily in May 2006.</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6410">
+                    <attributeName>cycle</attributeName>
+                    <attributeDefinition>Sequential Lagrangian Cycles</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sequential Lagrangian Cycles</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6411">
+                    <attributeName>size_fraction</attributeName>
+                    <attributeDefinition>Size Fraction of zooplankton sample considered (0.2-0.5 mm, 0.5-1.0 mm, 1.0-2.0 mm, 2.0-5.0 mm, > 5.0 mm, or Total [=all size fractions combined])</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">string</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Size Fraction of zooplankton sample considered (0.2-0.5 mm, 0.5-1.0 mm, 1.0-2.0 mm, 2.0-5.0 mm, > 5.0 mm, or Total [=all size fractions combined])</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6412">
+                    <attributeName>day_night</attributeName>
+                    <attributeDefinition>Indication of whether samples are daytime (centered on 1000), nighttime (centered on 2200), or the average of day and night samples</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">string</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Indication of whether samples are daytime (centered on 1000), nighttime (centered on 2200), or the average of day and night samples</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6413">
+                    <attributeName>biomass_mean</attributeName>
+                    <attributeDefinition>Mean zooplankton biomass per m3 for each Lagrangian Cycle, as dry mass</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>milligramsPerCubicMeter</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6414">
+                    <attributeName>biomass_std</attributeName>
+                    <attributeDefinition>Standard deviation of zooplankton biomass per m3 for each Lagrangian Cycle, as dry mass</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>milligramsPerCubicMeter</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6415">
+                    <attributeName>biomass_n</attributeName>
+                    <attributeDefinition>Sample size of zooplankton biomass per m3 for each Lagrangian Cycle</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sample size of zooplankton biomass per m3 for each Lagrangian Cycle</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6416">
+                    <attributeName>biomass_95cl</attributeName>
+                    <attributeDefinition>95% Confidence limit for zooplankton biomass per m3 for each Lagrangian Cycle, as dry mass</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>milligramsPerCubicMeter</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6417">
+                    <attributeName>int_biomass_mean</attributeName>
+                    <attributeDefinition>Mean zooplankton biomass vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle, as dry mass</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>milligramPerMeterSquared</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6418">
+                    <attributeName>int_biomass_std</attributeName>
+                    <attributeDefinition>Standard deviation of zooplankton biomass vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle, as dry mass</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>milligramPerMeterSquared</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6419">
+                    <attributeName>int_biomass_n</attributeName>
+                    <attributeDefinition>Sample size of zooplankton biomass vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sample size of zooplankton biomass vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6420">
+                    <attributeName>int_biomass_95cl</attributeName>
+                    <attributeDefinition>95% Confidence limit of zooplankton biomass vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle, as dry mass</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>milligramPerMeterSquared</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6421">
+                    <attributeName>chl_phaeo_mean</attributeName>
+                    <attributeDefinition>Mean concentration of ingested Chl-a + Phaeopgiments per m3, for each Lagrangian Cycle</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>microgramsPerCubicMeter</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6422">
+                    <attributeName>chl_phaeo_std</attributeName>
+                    <attributeDefinition>Standard deviation of ingested Chl-a + Phaeopgiments per m3, for each Lagrangian Cycle</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>microgramsPerCubicMeter</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6423">
+                    <attributeName>chl_phaeo_n</attributeName>
+                    <attributeDefinition>Sample size of ingested Chl-a + Phaeopgiments per m3, for each Lagrangian Cycle</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sample size of ingested Chl-a + Phaeopgiments per m3, for each Lagrangian Cycle</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6424">
+                    <attributeName>chl_phaeo_95cl</attributeName>
+                    <attributeDefinition>95% Confidence limit of ingested Chl-a + Phaeopgiments per m3, for each Lagrangian Cycle</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>microgramsPerCubicMeter</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6425">
+                    <attributeName>int_chl_phaeo_mean</attributeName>
+                    <attributeDefinition>Mean ingested Chl+Phaeopigments vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle in micrograms Chla+Phaeo/m2</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Mean ingested Chl+Phaeopigments vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle in micrograms Chla+Phaeo/m2</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6426">
+                    <attributeName>int_chl_phaeo_std</attributeName>
+                    <attributeDefinition>Standard deviation of ingested Chl+Phaeopigments vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle in micrograms Chla+Phaeo/m2</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Standard deviation of ingested Chl+Phaeopigments vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle in micrograms Chla+Phaeo/m2</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6427">
+                    <attributeName>int_chl_phaeo_n</attributeName>
+                    <attributeDefinition>Sample size of ingested Chl+Phaeopigments vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sample size of ingested Chl+Phaeopigments vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6428">
+                    <attributeName>int_chl_phaeo_95cl</attributeName>
+                    <attributeDefinition>95% Confidence limit of ingested Chl+Phaeopigments vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle in micrograms Chla+Phaeo/m2</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>95% Confidence limit of ingested Chl+Phaeopigments vertically integrated from the surface to the deepest sampling depth for each Lagrangian Cycle in micrograms Chla+Phaeo/m2</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6429">
+                    <attributeName>grazing_rate_mean</attributeName>
+                    <attributeDefinition>Mean ingestion rate of ingested Chl-a + Phaeopgiments per m3 per hr, for each Lagrangian Cycle micrograms Chla+Phaeo/m3/hr</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Mean ingestion rate of ingested Chl-a + Phaeopgiments per m3 per hr, for each Lagrangian Cycle micrograms Chla+Phaeo/m3/hr</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6430">
+                    <attributeName>grazing_rate_std</attributeName>
+                    <attributeDefinition>Standard deviation of ingestion rate of ingested Chl-a + Phaeopgiments per m3 per hr, for each Lagrangian Cycle in micrograms Chla+Phaeo/m3/hr</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Standard deviation of ingestion rate of ingested Chl-a + Phaeopgiments per m3 per hr, for each Lagrangian Cycle in micrograms Chla+Phaeo/m3/hr</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6431">
+                    <attributeName>grazing_rate_n</attributeName>
+                    <attributeDefinition>Sample size of ingestion rate of ingested Chl-a + Phaeopgiments per m3 per hr, for each Lagrangian Cycle</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sample size of ingestion rate of ingested Chl-a + Phaeopgiments per m3 per hr, for each Lagrangian Cycle</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6432">
+                    <attributeName>grazing_rate_95cl</attributeName>
+                    <attributeDefinition>95% Confidence limit of ingestion rate of ingested Chl-a + Phaeopgiments per m3 per hr, for each Lagrangian Cycle in micrograms Chla+Phaeo/m3/hr</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>95% Confidence limit of ingestion rate of ingested Chl-a + Phaeopgiments per m3 per hr, for each Lagrangian Cycle in micrograms Chla+Phaeo/m3/hr</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6433">
+                    <attributeName>int_grazing_rate_mean</attributeName>
+                    <attributeDefinition>Mean vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (micrograms)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>microgramPerMeterSquaredPerDay</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6434">
+                    <attributeName>int_grazing_rate_std</attributeName>
+                    <attributeDefinition>Standard deviation of vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (micrograms)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>microgramPerMeterSquaredPerDay</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6435">
+                    <attributeName>int_grazing_rate_n</attributeName>
+                    <attributeDefinition>Sample size of vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (micrograms)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sample size of vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (micrograms)</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6436">
+                    <attributeName>int_grazing_rate_95cl</attributeName>
+                    <attributeDefinition>95% Confidence limit of vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (micrograms)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>microgramPerMeterSquaredPerDay</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6437">
+                    <attributeName>int_grazing_rate_mg_mean</attributeName>
+                    <attributeDefinition>Mean vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (mg)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>milligramPerMeterSquaredPerDay</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6438">
+                    <attributeName>int_grazing_rate_mg_std</attributeName>
+                    <attributeDefinition>Standard deviation of vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (mg)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>milligramPerMeterSquaredPerDay</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6439">
+                    <attributeName>int_grazing_rate_mg_n</attributeName>
+                    <attributeDefinition>Sample size of vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (mg)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sample size of vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (mg)</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6440">
+                    <attributeName>int_grazing_rate_mg_95cl</attributeName>
+                    <attributeDefinition>95% Confidence limit of vertically integrated ingestion rate of Chl-a + Phaeopgiments per m2 per day, for each Lagrangian Cycle (mg)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>milligramPerMeterSquaredPerDay</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6441">
+                    <attributeName>mass_specific_grazing_mean</attributeName>
+                    <attributeDefinition>Mean of mass-specific ingested pigments ( mg Chl-a + Phaeo ingested / mg zooplankton biomass)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>microgramsPerMilligram</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6442">
+                    <attributeName>mass_specific_grazing_std</attributeName>
+                    <attributeDefinition>Standard deviation of mass-specific ingested pigments ( ug Chl-a + Phaeo ingested / mg zooplankton biomass)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>microgramsPerMilligram</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6443">
+                    <attributeName>mass_specific_grazing_n</attributeName>
+                    <attributeDefinition>Sample size of mass-specific ingested pigments </attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sample size of mass-specific ingested pigments </definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6444">
+                    <attributeName>mass_specific_grazing_95cl</attributeName>
+                    <attributeDefinition>95% Confidence limit of mass-specific ingested pigments </attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <ratio>
+                            <unit>
+                                <customUnit>microgramsPerMilligram</customUnit>
+                            </unit>
+                            <numericDomain>
+                                <numberType>real</numberType>
+                            </numericDomain>
+                        </ratio>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6445">
+                    <attributeName>mass_specific_grazing_rate_mean</attributeName>
+                    <attributeDefinition>Mean of mass-specific grazing rate ( mg Chl-a + Phaeo ingested / mg zooplankton biomass/day) micrograms Chla+Phaeo/milligram biomass/day</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Mean of mass-specific grazing rate ( mg Chl-a + Phaeo ingested / mg zooplankton biomass/day) micrograms Chla+Phaeo/milligram biomass/day</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6446">
+                    <attributeName>mass_specific_grazing_rate_std</attributeName>
+                    <attributeDefinition>Standard deviation of mass-specific grazing rate ( mg Chl-a + Phaeo ingested / mg zooplankton biomass/day) </attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Standard deviation of mass-specific grazing rate ( mg Chl-a + Phaeo ingested / mg zooplankton biomass/day) </definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6447">
+                    <attributeName>mass_specific_grazing_rate_n</attributeName>
+                    <attributeDefinition>Sample size of mass-specific grazing rate</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">integer</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>Sample size of mass-specific grazing rate</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+                <attribute id="311.table_321.col_6448">
+                    <attributeName>mass_specific_grazing_rate_95cl</attributeName>
+                    <attributeDefinition>95% Confidence limit of mass-specific grazing rate ( ug Chl-a + Phaeo ingested / mg zooplankton biomass/day)</attributeDefinition>
+                    <storageType typeSystem="http://www.w3.org/2001/XMLSchema-datatypes">float</storageType>
+                    <measurementScale>
+                        <nominal>
+                            <nonNumericDomain>
+                                <textDomain>
+                                    <definition>95% Confidence limit of mass-specific grazing rate ( ug Chl-a + Phaeo ingested / mg zooplankton biomass/day)</definition>
+                                </textDomain>
+                            </nonNumericDomain>
+                        </nominal>
+                    </measurementScale>
+                    <missingValueCode>
+                        <code>NULL</code>
+                        <codeExplanation>No data available</codeExplanation>
+                    </missingValueCode>
+                </attribute>
+            </attributeList>
+        </dataTable>
+    </dataset>
+    <additionalMetadata>
+        <metadata>
+            <stmml:unitList xmlns="http://www.xml-cml.org/schema/stmml" xmlns:sch="http://www.ascc.net/xml/schematron" xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.xml-cml.org/schema/stmml-1.1 stmml.xsd">
+                <stmml:unitType id="length" name="length">
+                    <stmml:dimension name="length"/>
+                </stmml:unitType>
+                <stmml:unitType id="massDensity" name="massDensity">
+                    <stmml:dimension name="length" power="-3"/>
+                    <stmml:dimension name="mass"/>
+                </stmml:unitType>
+                <stmml:unitType id="arealMassDensity" name="arealMassDensity">
+                    <stmml:dimension name="length" power="-2"/>
+                    <stmml:dimension name="mass"/>
+                </stmml:unitType>
+                <stmml:unitType id="arealMassDensityRate" name="arealMassDensityRate">
+                    <stmml:dimension name="length" power="-2"/>
+                    <stmml:dimension name="mass"/>
+                    <stmml:dimension name="time" power="-1"/>
+                </stmml:unitType>
+                <stmml:unitType id="massPerMass" name="massPerMass">
+                    <stmml:dimension name="mass"/>
+                </stmml:unitType>
+                <stmml:unit abbreviation="m" id="meter" name="meter" unitType="length">
+                    <stmml:description>SI unit of length</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="" id="kilogramPerCubicMeter" name="kilogramPerCubicMeter" unitType="massDensity">
+                    <stmml:description>kilogram per cubic meter</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="kg/m²" id="kilogramsPerSquareMeter" name="kilogramsPerSquareMeter" unitType="arealMassDensity">
+                    <stmml:description>kilograms per square meter</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="" id="kilogramsPerMeterSquaredPerSecond" name="kilogramsPerMeterSquaredPerSecond" unitType="arealMassDensityRate">
+                    <stmml:description>kilograms per meter sqared per second</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="" id="gramsPerGram" name="gramsPerGram" unitType="massPerMass">
+                    <stmml:description>grams per gram</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="mm" constantToSI="0" id="millimeter" multiplierToSI="0.001" name="millimeter" parentSI="meter" unitType="length">
+                    <stmml:description>.001 meters</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="mg/m³" constantToSI="0" id="milligramsPerCubicMeter" multiplierToSI="0.000001" name="milligramsPerCubicMeter" parentSI="kilogramPerCubicMeter" unitType="massDensity">
+                    <stmml:description>milligrams Per Cubic Meter</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="mg/m²" constantToSI="0" id="milligramPerMeterSquared" multiplierToSI="0.000001" name="milligramPerMeterSquared" parentSI="kilogramsPerSquareMeter" unitType="arealMassDensity">
+                    <stmml:description>milligrams Per Square Meter</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="" id="microgramsPerCubicMeter" name="microgramsPerCubicMeter" unitType="">
+                    <stmml:description/>
+                </stmml:unit>
+                <stmml:unit abbreviation="µg/m²/day" constantToSI="0" id="microgramPerMeterSquaredPerDay" multiplierToSI="1" name="microgramPerMeterSquaredPerDay" parentSI="kilogramsPerMeterSquaredPerSecond" unitType="arealMassDensityRate">
+                    <stmml:description>areal primary production rate</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="mg/m²/day" constantToSI="0" id="milligramPerMeterSquaredPerDay" multiplierToSI="86400000000" name="milligramPerMeterSquaredPerDay" parentSI="kilogramsPerMeterSquaredPerSecond" unitType="arealMassDensityRate">
+                    <stmml:description>areal primary production rate</stmml:description>
+                </stmml:unit>
+                <stmml:unit abbreviation="ug/mg" constantToSI="0" id="microgramsPerMilligram" multiplierToSI="0.001" name="microgramsPerMilligram" parentSI="gramsPerGram" unitType="massPerMass">
+                    <stmml:description>micrograms per milligram</stmml:description>
+                </stmml:unit>
+            </stmml:unitList>
+        </metadata>
+    </additionalMetadata>
+</eml:eml>

--- a/d1lod/tests/data/sysmeta/eml-200-sysmeta.xml
+++ b/d1lod/tests/data/sysmeta/eml-200-sysmeta.xml
@@ -1,0 +1,37 @@
+<ns3:systemMetadata xmlns:ns2="http://ns.dataone.org/service/types/v1" xmlns:ns3="http://ns.dataone.org/service/types/v2.0">
+    <serialVersion>1</serialVersion>
+    <identifier>doi:10.5063/AA/connolly.116.1</identifier>
+    <formatId>eml://ecoinformatics.org/eml-2.0.0</formatId>
+    <size>17564</size>
+    <checksum algorithm="MD5">82aff4056863ff31feeec899de5c232c</checksum>
+    <submitter>CN=Rani Gaddam A244621,O=University of California\, Santa Cruz,C=US,DC=cilogon,DC=org</submitter>
+    <rightsHolder>CN=Rani Gaddam A244621,O=University of California\, Santa Cruz,C=US,DC=cilogon,DC=org</rightsHolder>
+    <accessPolicy>
+        <allow>
+            <subject>public</subject>
+            <permission>read</permission>
+        </allow>
+        <allow>
+            <subject>CN=PISCO-data-managers,DC=dataone,DC=org</subject>
+            <permission>read</permission>
+            <permission>write</permission>
+            <permission>changePermission</permission>
+        </allow>
+    </accessPolicy>
+    <replicationPolicy replicationAllowed="false"/>
+    <archived>false</archived>
+    <dateUploaded>2019-09-26T21:53:44.885+00:00</dateUploaded>
+    <dateSysMetadataModified>2022-02-25T05:25:17.204+00:00</dateSysMetadataModified>
+    <originMemberNode>urn:node:PISCO</originMemberNode>
+    <authoritativeMemberNode>urn:node:PISCO</authoritativeMemberNode>
+    <replica>
+        <replicaMemberNode>urn:node:CN</replicaMemberNode>
+        <replicationStatus>completed</replicationStatus>
+        <replicaVerified>2019-09-27T02:50:53.962+00:00</replicaVerified>
+    </replica>
+    <replica>
+        <replicaMemberNode>urn:node:PISCO</replicaMemberNode>
+        <replicationStatus>completed</replicationStatus>
+        <replicaVerified>2019-09-27T02:50:53.943+00:00</replicaVerified>
+    </replica>
+</ns3:systemMetadata>

--- a/d1lod/tests/data/sysmeta/eml-201-sysmeta.xml
+++ b/d1lod/tests/data/sysmeta/eml-201-sysmeta.xml
@@ -1,0 +1,38 @@
+<ns3:systemMetadata xmlns:ns2="http://ns.dataone.org/service/types/v1" xmlns:ns3="http://ns.dataone.org/service/types/v2.0">
+    <serialVersion>1</serialVersion>
+    <identifier>doi:10.6085/AA/ICMDXX_XXXITV2XMSR01_20170101.50.1</identifier>
+    <formatId>eml://ecoinformatics.org/eml-2.0.1</formatId>
+    <size>17564</size>
+    <checksum algorithm="MD5">82aff4056863ff31feeec899de5c232b</checksum>
+    <submitter>CN=Rani Gaddam A244621,O=University of California\, Santa Cruz,C=US,DC=cilogon,DC=org</submitter>
+    <rightsHolder>CN=Rani Gaddam A244621,O=University of California\, Santa Cruz,C=US,DC=cilogon,DC=org</rightsHolder>
+    <accessPolicy>
+        <allow>
+            <subject>public</subject>
+            <permission>read</permission>
+        </allow>
+        <allow>
+            <subject>CN=PISCO-data-managers,DC=dataone,DC=org</subject>
+            <permission>read</permission>
+            <permission>write</permission>
+            <permission>changePermission</permission>
+        </allow>
+    </accessPolicy>
+    <replicationPolicy replicationAllowed="false"/>
+    <obsoletedBy>doi:10.6085/AA/ICMDXX_XXXITV2XMSR01_20170101.50.2</obsoletedBy>
+    <archived>false</archived>
+    <dateUploaded>2019-09-26T21:53:44.885+00:00</dateUploaded>
+    <dateSysMetadataModified>2022-02-25T05:25:17.204+00:00</dateSysMetadataModified>
+    <originMemberNode>urn:node:PISCO</originMemberNode>
+    <authoritativeMemberNode>urn:node:PISCO</authoritativeMemberNode>
+    <replica>
+        <replicaMemberNode>urn:node:CN</replicaMemberNode>
+        <replicationStatus>completed</replicationStatus>
+        <replicaVerified>2019-09-27T02:50:53.962+00:00</replicaVerified>
+    </replica>
+    <replica>
+        <replicaMemberNode>urn:node:PISCO</replicaMemberNode>
+        <replicationStatus>completed</replicationStatus>
+        <replicaVerified>2019-09-27T02:50:53.943+00:00</replicaVerified>
+    </replica>
+</ns3:systemMetadata>

--- a/d1lod/tests/data/sysmeta/eml-210-sysmeta.xml
+++ b/d1lod/tests/data/sysmeta/eml-210-sysmeta.xml
@@ -1,0 +1,13 @@
+<v2:systemMetadata xmlns:v2="http://ns.dataone.org/service/types/v2.0">
+  <identifier>eml-210</identifier>
+  <formatId>https://eml.ecoinformatics.org/eml-2.1.0</formatId>
+  <size>1234</size>
+  <checksum algorithm="SHA1">SHA1</checksum>
+  <submitter>test_submitter</submitter>
+  <rightsHolder>test_rights_holder</rightsHolder>
+  <dateUploaded>2021-06-01T00:00:00</dateUploaded>
+  <dateSysMetadataModified>2021-06-01T00:00:00</dateSysMetadataModified>
+  <originMemberNode>test_originating_mn</originMemberNode>
+  <authoritativeMemberNode>test_authoritative_mn</authoritativeMemberNode>
+  <fileName>eml-210.xml</fileName>
+</v2:systemMetadata>

--- a/d1lod/tests/data/sysmeta/eml-211-sysmeta.xml
+++ b/d1lod/tests/data/sysmeta/eml-211-sysmeta.xml
@@ -1,0 +1,13 @@
+<v2:systemMetadata xmlns:v2="http://ns.dataone.org/service/types/v2.0">
+  <identifier>eml-211</identifier>
+  <formatId>https://eml.ecoinformatics.org/eml-2.1.1</formatId>
+  <size>1234</size>
+  <checksum algorithm="SHA1">SHA1</checksum>
+  <submitter>test_submitter</submitter>
+  <rightsHolder>test_rights_holder</rightsHolder>
+  <dateUploaded>2021-06-01T00:00:00</dateUploaded>
+  <dateSysMetadataModified>2021-06-01T00:00:00</dateSysMetadataModified>
+  <originMemberNode>test_originating_mn</originMemberNode>
+  <authoritativeMemberNode>test_authoritative_mn</authoritativeMemberNode>
+  <fileName>eml-211.xml</fileName>
+</v2:systemMetadata>

--- a/d1lod/tests/test_eml201_processor.py
+++ b/d1lod/tests/test_eml201_processor.py
@@ -14,8 +14,6 @@ def test_processor_extracts_top_metadata(client, model):
 
     processor = EML210Processor(client, model, sysmeta, metadata, [])
     processor.process()
-    for m in processor.model:
-        print(m)
     node_id = "https://dataone.org/datasets/doi%3A10.6085%2FAA%2FICMDXX_XXXITV2XMSR01_20170101.50.1"
 
     # Create the alternateIdentifier node
@@ -24,7 +22,6 @@ def test_processor_extracts_top_metadata(client, model):
         RDF.Node(RDF.Uri("https://schema.org/identifier")),
         RDF.Node("doi:10.6085/AA/ICMDXX_XXXITV2XMSR01_20170101.50.1"),
     )
-    print(statement)
     assert model_has_statement(processor.model, statement)
     # Create the title node
     statement = RDF.Statement(

--- a/d1lod/tests/test_eml201_processor.py
+++ b/d1lod/tests/test_eml201_processor.py
@@ -1,0 +1,61 @@
+import RDF
+
+from d1lod.processors.eml.eml210_processor import EML210Processor
+from d1lod.processors.util import model_has_statement
+
+from .conftest import load_metadata, load_sysmeta
+
+
+# Tests that the processor extracts the non-complex (ie not people) top level eml dataset attributes:
+# alternateIdentifier, title, abstract, pubDate, keywordSet
+def test_processor_extracts_top_metadata(client, model):
+    metadata = load_metadata("eml/eml-201.xml")
+    sysmeta = load_sysmeta("eml-201-sysmeta.xml")
+
+    processor = EML210Processor(client, model, sysmeta, metadata, [])
+    processor.process()
+    for m in processor.model:
+        print(m)
+    node_id = "https://dataone.org/datasets/doi%3A10.6085%2FAA%2FICMDXX_XXXITV2XMSR01_20170101.50.1"
+
+    # Create the alternateIdentifier node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/identifier")),
+        RDF.Node("doi:10.6085/AA/ICMDXX_XXXITV2XMSR01_20170101.50.1"),
+    )
+    print(statement)
+    assert model_has_statement(processor.model, statement)
+    # Create the title node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/name")),
+        RDF.Node("MARINe/PISCO: Intertidal: site temperature data: Cape Mendocino (ICMDXX)"),
+    )
+    assert model_has_statement(processor.model, statement)
+    # Create the abstract node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/description")),
+        RDF.Node("This metadata record describes a mix of intertidal seawater and air "
+                 "temperature data collected at Cape Mendocino by MARINe/PISCO. Measurements were collected "
+                 "using Temperature Loggers from Onset Computer Corp"),
+    )
+    assert model_has_statement(processor.model, statement)
+    # Create the pubDatenode
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/datePublished")),
+        RDF.Node("2019-09-26"),
+    )
+    assert model_has_statement(processor.model, statement)
+    for keyword in ["EARTH SCIENCE : Oceans : Ocean Temperature : Water Temperature",
+                    "Temperature", "Integrated Ocean Observing System", "IOOS", "Oceanographic Sensor Data",
+                    "Intertidal Temperature Data", "continental shelf", "seawater", "temperature"]:
+        # Create the keywordSet node
+        statement = RDF.Statement(
+            RDF.Node(RDF.Uri(node_id)),
+            RDF.Node(RDF.Uri("https://schema.org/keyword")),
+            RDF.Node(keyword),
+        )
+        assert model_has_statement(processor.model, statement)

--- a/d1lod/tests/test_eml210_processor.py
+++ b/d1lod/tests/test_eml210_processor.py
@@ -14,8 +14,6 @@ def test_processor_extracts_top_metadata(client, model):
 
     processor = EML210Processor(client, model, sysmeta, metadata, [])
     processor.process()
-    for m in processor.model:
-        print(m)
     node_id = "https://dataone.org/datasets/eml-210"
 
     # Create the alternateIdentifier node
@@ -24,7 +22,6 @@ def test_processor_extracts_top_metadata(client, model):
         RDF.Node(RDF.Uri("https://schema.org/identifier")),
         RDF.Node("2002-2013_Kling_AON_Imnavait_Chemistry.06"),
     )
-    print(statement)
     assert model_has_statement(processor.model, statement)
     # Create the title node
     statement = RDF.Statement(

--- a/d1lod/tests/test_eml210_processor.py
+++ b/d1lod/tests/test_eml210_processor.py
@@ -1,0 +1,65 @@
+import RDF
+
+from d1lod.processors.eml.eml210_processor import EML210Processor
+from d1lod.processors.util import model_has_statement
+
+from .conftest import load_metadata, load_sysmeta
+
+
+# Tests that the processor extracts the non-complex (ie not people) top level eml dataset attributes:
+# alternateIdentifier, title, abstract, pubDate, keywordSet
+def test_processor_extracts_top_metadata(client, model):
+    metadata = load_metadata("eml/eml-210.xml")
+    sysmeta = load_sysmeta("eml-210-sysmeta.xml")
+
+    processor = EML210Processor(client, model, sysmeta, metadata, [])
+    processor.process()
+    for m in processor.model:
+        print(m)
+    node_id = "https://dataone.org/datasets/eml-210"
+
+    # Create the alternateIdentifier node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/identifier")),
+        RDF.Node("2002-2013_Kling_AON_Imnavait_Chemistry.06"),
+    )
+    print(statement)
+    assert model_has_statement(processor.model, statement)
+    # Create the title node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/name")),
+        RDF.Node("Biogeochemistry data set for Imnavait Creek Weir on the North Slope of Alaska."),
+    )
+    assert model_has_statement(processor.model, statement)
+    # Create the abstract node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/description")),
+        RDF.Node("Data file describing the biogeochemistry of samples collected at Imnavait Creek "
+                 ",North Slope of Alaska. Sample site descriptors include a unique assigned number "
+                 "(sortchem), site, date, time, depth, distance (downstream), elevation, and category. "
+                 "Physical measures collected in the field include temperature, conductivity, pH. "
+                 "Chemical analysis for the sample include alkalinity; dissolved organic carbon (DOC); "
+                 "inorganic and total dissolved nutrients (NH4, PO4, NO3, TDN, TDP); particulate carbon, "
+                 "nitrogen, and phosphorus (PC, PN, and PP); cations (Ca, Mg, Na, K); anions (SO4 and Cl); "
+                 "silica and oxygen."),
+    )
+    assert model_has_statement(processor.model, statement)
+    # Create the pubDatenode
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/datePublished")),
+        RDF.Node("2014"),
+    )
+    assert model_has_statement(processor.model, statement)
+    for keyword in ["carbon", "nitrogen", "phosphorus", "ammonium", "total dissolved nitrogen",
+                    "alkalinity", "dissolved organic carbon", "carbon dioxide", "methane"]:
+        # Create the keywordSet node
+        statement = RDF.Statement(
+            RDF.Node(RDF.Uri(node_id)),
+            RDF.Node(RDF.Uri("https://schema.org/keyword")),
+            RDF.Node(keyword),
+        )
+        assert model_has_statement(processor.model, statement)

--- a/d1lod/tests/test_eml211_processor.py
+++ b/d1lod/tests/test_eml211_processor.py
@@ -15,8 +15,6 @@ def test_processor_extracts_top_metadata(client, model):
 
     processor = EML210Processor(client, model, sysmeta, metadata, [])
     processor.process()
-    for m in processor.model:
-        print(m)
     node_id = "https://dataone.org/datasets/eml-211"
 
     # Create the alternateIdentifier node
@@ -25,7 +23,6 @@ def test_processor_extracts_top_metadata(client, model):
         RDF.Node(RDF.Uri("https://schema.org/identifier")),
         RDF.Node("311"),
     )
-    print(statement)
     assert model_has_statement(processor.model, statement)
     # Create the title node
     statement = RDF.Statement(

--- a/d1lod/tests/test_eml211_processor.py
+++ b/d1lod/tests/test_eml211_processor.py
@@ -1,0 +1,72 @@
+import textwrap
+import RDF
+
+from d1lod.processors.eml.eml210_processor import EML210Processor
+from d1lod.processors.util import model_has_statement
+
+from .conftest import load_metadata, load_sysmeta
+
+
+# Tests that the processor extracts the non-complex (ie not people) top level eml dataset attributes:
+# alternateIdentifier, title, abstract, pubDate, keywordSet
+def test_processor_extracts_top_metadata(client, model):
+    metadata = load_metadata("eml/eml-211.xml")
+    sysmeta = load_sysmeta("eml-211-sysmeta.xml")
+
+    processor = EML210Processor(client, model, sysmeta, metadata, [])
+    processor.process()
+    for m in processor.model:
+        print(m)
+    node_id = "https://dataone.org/datasets/eml-211"
+
+    # Create the alternateIdentifier node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/identifier")),
+        RDF.Node("311"),
+    )
+    print(statement)
+    assert model_has_statement(processor.model, statement)
+    # Create the title node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/name")),
+        RDF.Node("Gut Fluorescence measurements of mesozooplankton grazing on autotrophic prey. "
+                 "Samples collected in the CCE-LTER region on Process Cruises from 2006 to the present. "
+                 "Summaries for each Lagrangian Cycle."),
+    )
+    assert model_has_statement(processor.model, statement)
+    # Create the abstract node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/description")),
+        RDF.Node("Mesozooplankton are collected with plankton nets (typically a 71-cm diameter, 202-um mesh Bongo net)"
+                 " and samples flash frozen at sea in liquid N2 for subsequent shore-based measurements of ingested "
+                 "phytoplankton chlorophyll-a. Measurements of mesozooplankton gut fluorescence are done by "
+                 "fluorometric analysis on a Turner Designs fluorometer of gut pigments extracted in 90% acetone. "
+                 "Analyses are done on mesozooplankton size-fractionated into 5 different categories on Nitex mesh "
+                 "(> 0.2 mm, 0.5 mm, 1.0 mm, 2.0 mm, 5.0 mm). The pigment content (as Chl-a and phaeopigments) is "
+                 "then expressed as mass of pigment ingested per m3 of water filtered, or divided by the dry weight "
+                 "biomass of the mesozooplankton in the same sample in order to obtain mass-specific ingestion per "
+                 "m3 of water. Application of published values of the temperature-dependent gut passage time are used "
+                 "to estimate the mesozooplankton grazing rate, as pigments ingested per m3 per unit time, or the "
+                 "corresponding mass-specific rate of ingestion. Samples for gut fluorescence assays have been "
+                 "collected on CCE-LTER Process Cruises since 2006 and these collections are ongoing."),
+    )
+    assert model_has_statement(processor.model, statement)
+    # Create the pubDate node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/datePublished")),
+        RDF.Node("2021-10-29"),
+    )
+    assert model_has_statement(processor.model, statement)
+    for keyword in ["biogeochemistry", "carbon flux", "chlorophyll a", "grazing", "herbivory",
+                    "Mesozooplankton"]:
+        # Create the keywordSet node
+        statement = RDF.Statement(
+            RDF.Node(RDF.Uri(node_id)),
+            RDF.Node(RDF.Uri("https://schema.org/keyword")),
+            RDF.Node(keyword),
+        )
+        assert model_has_statement(processor.model, statement)

--- a/d1lod/tests/test_eml220_processor.py
+++ b/d1lod/tests/test_eml220_processor.py
@@ -28,10 +28,6 @@ def test_processor_extracts_entity_level_annotations(client, model):
 
     processor = EML220Processor(client, model, sysmeta, metadata, [])
     processor.process()
-
-    for s in processor.model:
-        print(s)
-
     statement = RDF.Statement(
         RDF.Node(
             RDF.Uri("https://dataone.org/datasets/eml-annotation-gym#my.data.table")
@@ -49,10 +45,6 @@ def test_processor_extracts_attribute_level_annotations(client, model):
 
     processor = EML220Processor(client, model, sysmeta, metadata, [])
     processor.process()
-
-    for s in processor.model:
-        print(s)
-
     statement = RDF.Statement(
         RDF.Node(
             RDF.Uri("https://dataone.org/datasets/eml-annotation-gym#my.attribute")

--- a/d1lod/tests/test_eml_processor.py
+++ b/d1lod/tests/test_eml_processor.py
@@ -82,3 +82,73 @@ def test_attribute_with_annotations_are_extracted_correctly(client, model):
     )
 
     assert model_has_statement(processor.model, statement)
+
+# Test that the processor can handle 2.0.0 documents
+
+# Tests that the processor extracts the non-complex (ie not people) top level eml dataset attributes:
+# alternateIdentifier, title, abstract, pubDate, keywordSet
+def test_processor_extracts_top_metadata(client, model):
+    metadata = load_metadata("eml/eml-200.xml")
+    sysmeta = load_sysmeta("eml-200-sysmeta.xml")
+
+    processor = EMLProcessor(client, model, sysmeta, metadata, [])
+    processor.process()
+    node_id = "https://dataone.org/datasets/doi%3A10.5063%2FAA%2Fconnolly.116.1"
+
+    # Create the alternateIdentifier node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/identifier")),
+        RDF.Node("doi:10.5063/AA/connolly.116.1"),
+    )
+
+    assert model_has_statement(processor.model, statement)
+    # Create the title node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/name")),
+        RDF.Node("Parallel effects of land-use history on species diversity and genetic diversity of forest herbs."),
+    )
+    assert model_has_statement(processor.model, statement)
+    # Create the abstract node
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/description")),
+        RDF.Node("The two most fundamental levels of biodiversity, species diversity and genetic diversity, are "
+                 "seldom studied simultaneously despite a strikingly similar set of processes that underlie "
+                 "patterns at the two levels. Agricultural land use drastically reduces populations of forest "
+                 "herbs in the north-temperate zone, so that bottlenecks or founder events in forests on abandoned "
+                 "agricultural land (i.e., secondary forests) may have a long-term impact on both species "
+                 "diversity and genetic diversity. Using forest-herb community surveys and molecular-genetic "
+                 "analysis of populations of Trillium grandiflorum, a representative species of forest herb, "
+                 "I investigated the influence of land-use history, landscape context, and environmental "
+                 "conditions on diversity and divergence at the population and community levels. Secondary "
+                 "forests (70100 years old) had reduced diversity of both genes and species relative to primary "
+                 "forests (i.e., stands never cleared for agriculture). The community in secondary forests had "
+                 "an overrepresentation of the most common species in the landscape, though divergence in species' "
+                 "relative abundances within stands suggested an influence of community drift via local bottlenecks. "
+                 "Secondary-forest populations of T. grandiflorum were more genetically divergent than those in "
+                 "primary forests, again indicating drift in small populations. Land-use history and the size of "
+                 "populations and communities drove correlations between species diversity and genetic diversity "
+                 "(and community divergence \u00D7 genetic divergence), though the strength of correlations was "
+                 "relatively weak. These results extend the generality of positive speciesgenetic diversity "
+                 "correlations previously observed for islands, and they demonstrate a long-term legacy of land-use "
+                 "history at multiple levels of biodiversity."),
+    )
+    assert model_has_statement(processor.model, statement)
+    # Create the pubDatenode
+    statement = RDF.Statement(
+        RDF.Node(RDF.Uri(node_id)),
+        RDF.Node(RDF.Uri("https://schema.org/datePublished")),
+        RDF.Node("2020-01-01"),
+    )
+    assert model_has_statement(processor.model, statement)
+    for keyword in ["biodiversity; forest herbs; genetic diversity; land-use history; species diversity; "
+                    "Tompkins County, New York (USA); forest stands; Trillium grandiflorum"]:
+        # Create the keywordSet node
+        statement = RDF.Statement(
+            RDF.Node(RDF.Uri(node_id)),
+            RDF.Node(RDF.Uri("https://schema.org/keyword")),
+            RDF.Node(keyword),
+        )
+        assert model_has_statement(processor.model, statement)


### PR DESCRIPTION
This PR adds support for triplifying EML documents version 2.0.0 and up, fixing issue #63. Because of the backwards compatibilities of EML, new processing logic wasn't needed. Instead, new classes for each processor were set up and added to the [format map](https://github.com/DataONEorg/slinky/blob/715bd5210b86728cf29d0d06460beb80519d0fc0/d1lod/d1lod/client.py#L23). The unit tests make up the bulk of this PR.

### Changes

1. The base EMLProcessor class is the 2.0.0 processor
2. Added EML 2.0.1 and 2.1.0 processors, each use the base processor
3. Unit tests for each of the processors
4. EML URI change [here](https://github.com/DataONEorg/slinky/blob/715bd5210b86728cf29d0d06460beb80519d0fc0/d1lod/d1lod/client.py#L28)

### Testing
To test, make sure that the unit tests are passing. This is deployed on the dev environment, so you can optionally query it to look into the data further.